### PR TITLE
Properly reread targets file

### DIFF
--- a/conf_files/huntsman.yaml
+++ b/conf_files/huntsman.yaml
@@ -16,6 +16,7 @@ location:
 scheduler:
     type: dispatch
     fields_file: targets.yaml
+    check_file: True
 directories:
     base: /var/huntsman
     data: data

--- a/states/huntsman/scheduling.py
+++ b/states/huntsman/scheduling.py
@@ -22,7 +22,7 @@ def on_enter(event_data):
 
         # Get the next observation
         try:
-            observation = pocs.observatory.get_observation(reread_fields_file=True)
+            observation = pocs.observatory.get_observation()
             pocs.logger.info("Observation: {}".format(observation))
 
             if pocs.force_reschedule:


### PR DESCRIPTION
The property is now read from the config, which we set to True by default.