### PR TITLE
Fixing pyro result

### DIFF
--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -383,7 +383,12 @@ class Camera(AbstractCamera):
     def _async_wait(self, future_result, name='?', event=None, timeout=None):
         # For now not checking for any problems, just wait for everything to return (or timeout)
         if future_result.wait(timeout):
-            result = future_result.value
+            try:
+                result = future_result.value
+            except Exception as e:
+                self.logger.debug("Problem in wait: {}".format(e))
+                result = True
+                self.logger.debug("Setting result to True anyway")
         else:
             msg = "Timeout while waiting for {} on {}".format(name, self.name)
             warn(msg)


### PR DESCRIPTION
This is the fix that was implemented during a testing run. This isn't really a fix for the problem but at least lets us work. Seems like Pyro was trying to serialize an astropy Quantity but it was really unclear where that was coming from. Ultimately the `_async_wait` just wants a success boolean so here we capture the error and then set to True. Could have bad side effects.

We'll need to merge this in to continue work but @AnthonyHorton might have some suggestions as to real fix.