### PR TITLE
Fixes to analyzing state logic for reschedule

### DIFF
--- a/states/huntsman/analyzing.py
+++ b/states/huntsman/analyzing.py
@@ -8,16 +8,15 @@ def on_enter(event_data):
 
     pocs.next_state = 'dithering'
     try:
-
         pocs.observatory.analyze_recent()
-
-        if pocs.force_reschedule:
-            pocs.next_state = 'scheduling'
-
-        # Check for minimum number of exposures
-        if observation.current_exp_num >= observation.min_nexp:
-            # Check if we have completed an exposure block
-            if observation.current_exp_num % observation.exp_set_size == 0:
-                pocs.next_state = 'scheduling'
     except Exception as e:
         pocs.logger.error("Problem in analyzing: {}".format(e))
+
+    if pocs.force_reschedule:
+        pocs.next_state = 'scheduling'
+
+    # Check for minimum number of exposures
+    if observation.current_exp_num >= observation.min_nexp:
+        # Check if we have completed an exposure block
+        if observation.current_exp_num % observation.exp_set_size == 0:
+            pocs.next_state = 'scheduling'


### PR DESCRIPTION
The checks for rescheduling should always happen. This fixes a bug where the checks were being skipped if the `analyze_recent` call was failing. We made this change during an observation run in Oct.