### PR TITLE
Update camera properties and fix test suite

### DIFF
--- a/conf_files/huntsman.yaml
+++ b/conf_files/huntsman.yaml
@@ -34,9 +34,9 @@ cameras:
     auto_detect: False
     devices:
     -
-        model: simulator
+        model: simulator_sdk
     -
-        model: simulator    
+        model: simulator_sdk    
 dome:
     template_dir: resources/bisque
     driver: bisque

--- a/conf_files/pyro_camera.yaml
+++ b/conf_files/pyro_camera.yaml
@@ -37,8 +37,8 @@ directories:
 # host: 999.999.999.999
 # camera:
 #   model: sbig
-#   port: 83F012345
-#   set_point: 0
+#   serial_number: 83F012345
+#   target_temperature: 0
 #   filter_type: r2_6
 #   focuser:
 #     model: birger
@@ -59,8 +59,8 @@ directories:
 # host: 999.999.999.999
 # camera:
 #   model: fli
-#   port: ML12345
-#   set_point: -10
+#   serial_number: ML12345
+#   target_temperature: -10
 #   filter_type: r2_4
 #   focuser:
 #     model: birger
@@ -77,12 +77,12 @@ directories:
 #     autofocus_size: 1000
 #
 # FLI Camera with FocusLynx focuser:
-# name: camera.fli.002
+# name: camera.zwo.001
 # host: 999.999.999.999
 # camera:
-#   model: fli
-#   port: ML12345
-#   set_point: -10
+#   model: zwo
+#   serial_number: abcdef0123456789
+#   target_temperature: -10
 #   filter_type: g2_0
 #   focuser:
 #     model: focuslynx

--- a/conf_files/pyro_camera.yaml
+++ b/conf_files/pyro_camera.yaml
@@ -10,9 +10,9 @@
 name: camera.simulator.001
 host: localhost
 camera:
-  model: simulator
-  port: /dev/ttyFAKE01
-  set_point: 0
+  model: simulator_sdk
+  serial_number: SSC101
+  target_temperature: 20
   filter_type: r2_6
   focuser:
     model: simulator

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -461,7 +461,7 @@ class CameraServer(object):
 
     @target_temperature.setter
     def target_temperature(self, target):
-        self._camera.target_temperature = set_point
+        self._camera.target_temperature = target
 
     @property
     def cooling_enabled(self):

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -43,48 +43,48 @@ class Camera(AbstractCamera):
         return self._serial_number
 
     @property
-    def ccd_temp(self):
+    def temperature(self):
         """
         Current temperature of the camera's image sensor.
         """
-        return self._proxy.ccd_temp * u.Celsius
+        return self._proxy.temperature * u.Celsius
 
     @property
-    def ccd_set_point(self):
+    def target_temperature(self):
         """
         Current value of the CCD set point, the target temperature for the camera's
         image sensor cooling control.
 
         Can be set by assigning an astropy.units.Quantity.
         """
-        return self._proxy.ccd_set_point * u.Celsius
+        return self._proxy.target_temperature * u.Celsius
 
-    @ccd_set_point.setter
-    def ccd_set_point(self, set_point):
-        if isinstance(set_point, u.Quantity):
-            set_point = set_point.to(u.Celsius).value
-        self._proxy.ccd_set_point = float(set_point)
+    @target_temperature.setter
+    def target_temperature(self, target):
+        if isinstance(target, u.Quantity):
+            target = target.to(u.Celsius).value
+        self._proxy.target_temperature = float(target)
 
     @property
-    def ccd_cooling_enabled(self):
+    def cooling_enabled(self):
         """
         Current status of the camera's image sensor cooling system (enabled/disabled).
 
         For some cameras it is possible to change this by assigning a boolean
         """
-        return self._proxy.ccd_cooling_enabled
+        return self._proxy.cooling_enabled
 
-    @ccd_cooling_enabled.setter
-    def ccd_cooling_enabled(self, enabled):
-        self._proxy.ccd_cooling_enabled = bool(enabled)
+    @cooling_enabled.setter
+    def cooling_enabled(self, enabled):
+        self._proxy.cooling_enabled = bool(enabled)
 
     @property
-    def ccd_cooling_power(self):
+    def cooling_power(self):
         """
         Current power level of the camera's image sensor cooling system (typically as
         a percentage of the maximum).
         """
-        return self._proxy.ccd_cooling_power
+        return self._proxy.cooling_power
 
 # Methods
 
@@ -450,30 +450,30 @@ class CameraServer(object):
         return self._camera.readout_time
 
     @property
-    def ccd_temp(self):
-        temperature = self._camera.ccd_temp
+    def temperature(self):
+        temperature = self._camera.temperature
         return temperature.to(u.Celsius).value
 
     @property
-    def ccd_set_point(self):
-        temperature = self._camera.ccd_set_point
+    def target_temperature(self):
+        temperature = self._camera.target_temperature
         return temperature.to(u.Celsius).value
 
-    @ccd_set_point.setter
-    def ccd_set_point(self, set_point):
-        self._camera.ccd_set_point = set_point
+    @target_temperature.setter
+    def target_temperature(self, set_point):
+        self._camera.target_temperature = set_point
 
     @property
-    def ccd_cooling_enabled(self):
-        return self._camera.ccd_cooling_enabled
+    def cooling_enabled(self):
+        return self._camera.cooling_enabled
 
-    @ccd_cooling_enabled.setter
-    def ccd_cooling_enabled(self, enabled):
-        self._camera.ccd_cooling_enabled = enabled
+    @cooling_enabled.setter
+    def cooling_enabled(self, enabled):
+        self._camera.cooling_enabled = enabled
 
     @property
-    def ccd_cooling_power(self):
-        return self._camera.ccd_cooling_power
+    def cooling_power(self):
+        return self._camera.cooling_power
 
 # Methods
 

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -460,7 +460,7 @@ class CameraServer(object):
         return temperature.to(u.Celsius).value
 
     @target_temperature.setter
-    def target_temperature(self, set_point):
+    def target_temperature(self, target):
         self._camera.target_temperature = set_point
 
     @property

--- a/huntsman/tests/conftest.py
+++ b/huntsman/tests/conftest.py
@@ -18,7 +18,7 @@ from huntsman.utils import load_config
 _one_time_config = None
 # Global variable set to a bool by can_connect_to_mongo().
 _can_connect_to_mongo = None
-_all_databases = ['mongo', 'file', 'memory']
+_all_databases = ['file']
 
 
 def pytest_addoption(parser):

--- a/huntsman/tests/conftest.py
+++ b/huntsman/tests/conftest.py
@@ -110,6 +110,24 @@ def config(images_dir, messaging_ports):
     return result
 
 
+@pytest.fixture
+def config_with_simulated_stuff(config):
+    config.update({
+        'dome': {
+            'brand': 'Simulacrum',
+            'driver': 'simulator',
+            },
+        'mount': {
+            'model': 'simulator',
+            'driver': 'simulator',
+            'serial': {
+                'port': 'simulator'
+            }
+        },
+    })
+    return config
+
+
 def can_connect_to_mongo(db_name):
     global _can_connect_to_mongo
     if _can_connect_to_mongo is None:

--- a/huntsman/tests/test_camera.py
+++ b/huntsman/tests/test_camera.py
@@ -73,7 +73,7 @@ def test_uid(camera):
 
 def test_get_temp(camera):
     try:
-        temperature = camera.ccd_temp
+        temperature = camera.temperature
     except NotImplementedError:
         pytest.skip("Camera {} doesn't implement temperature info".format(camera.name))
     else:
@@ -82,25 +82,25 @@ def test_get_temp(camera):
 
 def test_set_set_point(camera):
     try:
-        camera.ccd_set_point = 10 * u.Celsius
+        camera.target_temperature = 10 * u.Celsius
     except NotImplementedError:
         pytest.skip("Camera {} doesn't implement temperature control".format(camera.name))
     else:
-        assert abs(camera.ccd_set_point - 10 * u.Celsius) < 0.5 * u.Celsius
+        assert abs(camera.target_temperature - 10 * u.Celsius) < 0.5 * u.Celsius
 
 
 def test_enable_cooling(camera):
     try:
-        camera.ccd_cooling_enabled = True
+        camera.cooling_enabled = True
     except NotImplementedError:
         pytest.skip("Camera {} doesn't implement control of cooling status".format(camera.name))
     else:
-        assert camera.ccd_cooling_enabled is True
+        assert camera.cooling_enabled is True
 
 
 def test_get_cooling_power(camera):
     try:
-        power = camera.ccd_cooling_power
+        power = camera.cooling_power
     except NotImplementedError:
         pytest.skip("Camera {} doesn't implement cooling power readout".format(camera.name))
     else:
@@ -109,11 +109,11 @@ def test_get_cooling_power(camera):
 
 def test_disable_cooling(camera):
     try:
-        camera.ccd_cooling_enabled = False
+        camera.cooling_enabled = False
     except NotImplementedError:
         pytest.skip("Camera {} doesn't implement control of cooling status".format(camera.name))
     else:
-        assert camera.ccd_cooling_enabled is False
+        assert camera.cooling_enabled is False
 
 
 def test_exposure(camera, tmpdir):

--- a/huntsman/tests/test_huntsman.py
+++ b/huntsman/tests/test_huntsman.py
@@ -42,52 +42,48 @@ def wait_for_state(sub, state, max_duration=90):
 
 
 @pytest.fixture(scope='function')
-def cameras(config):
+def cameras(config_with_simulated_stuff):
     """Get the default cameras from the config."""
-    config['simulator'] = ['camera']
-    return create_cameras_from_config(config)
+    return create_cameras_from_config(config_with_simulated_stuff)
 
 
 @pytest.fixture(scope='function')
-def scheduler(config):
-    site_details = create_location_from_config(config)
-    return create_scheduler_from_config(config, observer=site_details['observer'])
+def scheduler(config_with_simulated_stuff):
+    site_details = create_location_from_config(config_with_simulated_stuff)
+    return create_scheduler_from_config(config_with_simulated_stuff,
+                                        observer=site_details['observer'])
 
 
 @pytest.fixture(scope='function')
-def dome(config):
-    return create_dome_from_config(config)
+def dome(config_with_simulated_stuff):
+    return create_dome_from_config(config_with_simulated_stuff)
 
 
 @pytest.fixture(scope='function')
-def mount(config):
-    return create_mount_from_config(config)
+def mount(config_with_simulated_stuff):
+    return create_mount_from_config(config_with_simulated_stuff)
 
 
 @pytest.fixture(scope='function')
-def observatory(config, db_type, cameras, scheduler, dome, mount):
+def observatory(config_with_simulated_stuff, db_type, cameras, scheduler, dome, mount):
     observatory = Observatory(
-        config=config,
+        config=config_with_simulated_stuff,
         cameras=cameras,
         scheduler=scheduler,
         dome=dome,
         mount=mount,
-        simulator=['all'],
-        ignore_local_config=True,
         db_type=db_type
     )
     return observatory
 
 
 @pytest.fixture(scope='function')
-def pocs(config, observatory):
+def pocs(config_with_simulated_stuff, observatory):
     os.environ['POCSTIME'] = '2016-08-13 13:00:00'
 
     pocs = POCS(observatory,
                 run_once=True,
-                config=config,
-                simulator=['all'],
-                ignore_local_config=True)
+                config=config_with_simulated_stuff)
 
     yield pocs
 

--- a/huntsman/tests/test_huntsman.py
+++ b/huntsman/tests/test_huntsman.py
@@ -15,6 +15,7 @@ from huntsman.camera import create_cameras_from_config
 from pocs.utils.location import create_location_from_config
 from pocs.scheduler import create_scheduler_from_config
 from pocs.dome import create_dome_from_config
+from pocs.mount import create_mount_from_config
 
 from huntsman.camera.pyro import Camera as PyroCamera
 from huntsman.observatory import HuntsmanObservatory as Observatory
@@ -59,11 +60,18 @@ def dome(config):
 
 
 @pytest.fixture(scope='function')
-def observatory(config, db_type, cameras, scheduler, dome):
+def mount(config):
+    return create_mount_from_config(config)
+
+
+@pytest.fixture(scope='function')
+def observatory(config, db_type, cameras, scheduler, dome, mount):
     observatory = Observatory(
         config=config,
         cameras=cameras,
         scheduler=scheduler,
+        dome=dome,
+        mount=mount,
         simulator=['all'],
         ignore_local_config=True,
         db_type=db_type

--- a/huntsman/tests/test_huntsman_observatory.py
+++ b/huntsman/tests/test_huntsman_observatory.py
@@ -12,19 +12,3 @@ def test_bad_observatory(config):
         obs = HuntsmanObservatory()
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 'Must set HUNTSMAN_POCS variable'
-
-
-@pytest.fixture(scope='function')
-def cameras(config):
-    """Get the default cameras from the config."""
-    return create_cameras_from_config(config)
-
-
-@pytest.fixture(scope='function')
-def observatory(config, cameras):
-    observatory = Observatory(
-        config=config,
-        cameras=cameras,
-        simulator=['all'],
-    )
-    yield observatory


### PR DESCRIPTION
Update temperature control related camera property names in the Pyro camera classes to match those now used in POCS camera classes, and fix all the broken tests.