### PR TITLE
Don't perform a system exit if no local cameras are found.

### DIFF
--- a/huntsman/camera/__init__.py
+++ b/huntsman/camera/__init__.py
@@ -98,7 +98,7 @@ def create_cameras_from_config(config=None, logger=None, **kwargs):
 
     try:
         cameras = create_local_cameras(config=config, logger=logger, **kwargs)
-    except (error.PanError, KeyError, error.CameraNotFound):
+    except (error.PanError, KeyError, error.CameraNotFound, SystemExit):
         logger.debug("No local cameras")
         cameras = OrderedDict()
 


### PR DESCRIPTION
Note: this will still show a `TERMINATING: No cameras available. Exiting.` warning. Should get rid of that too as it doesn't really exit.

Really with the cameras separated from the Observatory in POCS that error should no longer be existing so perhaps I will just make the fix there instead.

Update: https://github.com/panoptes/POCS/pull/913