### PR TITLE
Add Pyro Focuser class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ notebooks/*
 
 # Ignore link to weather_plots in web/static/
 weather_plots
+
+src/

--- a/huntsman/camera/__init__.py
+++ b/huntsman/camera/__init__.py
@@ -156,14 +156,13 @@ def create_distributed_cameras(camera_info, logger=None):
     primary_id = camera_info.get('primary', '')
     for cam_name, cam_uri in camera_uris.items():
         logger.debug('Creating camera: {}'.format(cam_name))
-        cam = PyroCamera(name=cam_name, uri=cam_uri)
+        cam = PyroCamera(port=cam_name, uri=cam_uri)
         is_primary = ''
         if primary_id == cam.uid or primary_id == cam.name:
             cam.is_primary = True
             is_primary = ' [Primary]'
 
-        logger.debug("Camera created: {} {}{}".format(
-            cam.name, cam.uid, is_primary))
+        logger.debug(f"Camera created: {cam}")
 
         cameras[cam_name] = cam
 

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -76,7 +76,7 @@ class Camera(AbstractCamera):
 
     @temperature_tolerance.setter
     def temperature_tolerance(self, tolerance):
-        tolerance = get_quantity_value(tolerace, u.Celsius)
+        tolerance = get_quantity_value(tolerance, u.Celsius)
         self._proxy.temperature_tolerance = float(tolerance)
 
     @property

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -46,7 +46,7 @@ class Camera(AbstractCamera):
         if self._egain is not None:
             return self._egain
         else:
-            raise NotImplementError
+            raise NotImplementedError
 
     @property
     def bit_depth(self):
@@ -153,7 +153,7 @@ class Camera(AbstractCamera):
         self._file_extension = self._proxy.file_extension
         try:
             self._egain = self._proxy.egain
-        except NotImplementError:
+        except NotImplementedError:
             self._egain = None
         try:
             self._bit_depth = self._proxy.bit_depth

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -606,7 +606,7 @@ class CameraServer(object):
     def focuser_autofocus_keep_files(self):
         return self._camera.focuser.autofocus_keep_files
 
-    @focuser_autofocus_keep_files
+    @focuser_autofocus_keep_files.setter
     def focuser_autofocus_keep_files(self, keep_files):
         self._camera.focuser.autofocus_keep_files = keep_files
 
@@ -638,7 +638,7 @@ class CameraServer(object):
     def focuser_autofocus_mask_dilations(self):
         return self._camera.focuser.autofocus_mask_dilations
 
-    @focuser_autofocus_mask_dilations
+    @focuser_autofocus_mask_dilations.setter
     def focuser_autofocus_mask_dilations(self, dilations):
         self._camera.focuser.autofocus_mask_dilations = dilations
 

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -445,7 +445,7 @@ class Camera(AbstractCamera):
             msg = "Timeout while waiting for {} on {}".format(name, self.name)
             warn(msg)
             self.logger.error(msg)
-            return False
+            result = False
 
         if event is not None:
             event.set()

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -516,7 +516,7 @@ class CameraServer(object):
 
     @property
     def temperature_tolerance(self):
-        return self._camera.temperature_tolerance
+        return get_quantity_value(self._camera.temperature_tolerance, u.Celsius)
 
     @temperature_tolerance.setter
     def temperature_tolerance(self, tolerance):

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -77,7 +77,12 @@ class Camera(AbstractCamera):
     @temperature_tolerance.setter
     def temperature_tolerance(self, tolerance):
         tolerance = get_quantity_value(tolerance, u.Celsius)
-        self._proxy.temperature_tolerance = float(tolerance)
+        try:
+            self._proxy.temperature_tolerance = float(tolerance)
+        except AttributeError:
+            # Base class constructor is trying to set a default temperature temperature
+            # before self._proxy exists, & it's up to the remote camera to do that anyway.
+            pass
 
     @property
     def cooling_enabled(self):

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -570,6 +570,78 @@ class CameraServer(object):
     def focuser_is_ready(self):
         return self._camera.focuser.is_ready
 
+    @property
+    def focuser_autofocus_range(self):
+        return self._camera.focuser.autofocus_range
+
+    @focuser_autofocus_range.setter
+    def focuser_autofocus_range(self, autofocus_range):
+        self._camera.focuser.autofocus_range = autofocus_range
+
+    @property
+    def focuser_autofocus_step(self):
+        return self._camera.focuser.autofocus_step
+
+    @focuser_autofocus_step.setter
+    def focuser_autofocus_step(self, step):
+        self._camera.focuser.autofocus_step = step
+
+    @property
+    def focuser_autofocus_seconds(self):
+        return self._camera.focuser.autofocus_seconds
+
+    @focuser_autofocus_seconds.setter
+    def focuser_autofocus_seconds(self, seconds):
+        self._camera.focuser.autofocus_seconds = seconds
+
+    @property
+    def focuser_autofocus_size(self):
+        return self._camera.focuser.autofocus_size
+
+    @focuser_autofocus_size.setter
+    def focuser_autofocus_size(self, size):
+        self._camera.focuser.autofocus_size = size
+
+    @property
+    def focuser_autofocus_keep_files(self):
+        return self._camera.focuser.autofocus_keep_files
+
+    @focuser_autofocus_keep_files
+    def focuser_autofocus_keep_files(self, keep_files):
+        self._camera.focuser.autofocus_keep_files = keep_files
+
+    @property
+    def focuser_autofocus_take_dark(self):
+        return self._camera.focuser.autofocus_take_dark
+
+    @focuser_autofocus_take_dark.setter
+    def focuser_autofocus_take_dark(self, take_dark):
+        self._camera.focuser.autofocus_take_dark = take_dark
+
+    @property
+    def focuser_autofocus_merit_function(self):
+        return self._camera.focuser.autofocus_merit_function
+
+    @focuser_autofocus_merit_function.setter
+    def focuser_autofocus_merit_function(self, merit_function):
+        self._camera.focuser.autofocus_merit_function = merit_function
+
+    @property
+    def focuser_autofocus_merit_function_kwargs(self):
+        return self._camera.focuser.autofocus_merit_function_kwargs
+
+    @focuser_autofocus_merit_function_kwargs.setter
+    def focuser_autofocus_merit_function_kwargs(self, kwargs):
+        self._camera.focuser.autofocus_merit_function_kwargs = kwargs
+
+    @property
+    def focuser_autofocus_mask_dilations(self):
+        return self._camera.focuser.autofocus_mask_dilations
+
+    @focuser_autofocus_mask_dilations
+    def focuser_autofocus_mask_dilations(self, dilations):
+        self._camera.focuser.autofocus_mask_dilations = dilations
+
     def focuser_move_to(self, position):
         return self._camera.focuser.move_to(position)
 

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -512,9 +512,13 @@ class CameraServer(object):
         return "{}@{}:{}".format(self.user, self.host, filename)
 
     def autofocus(self, *args, **kwargs):
+        if not self.has_focuser:
+            msg = "Camera must have a focuser for autofocus!"
+            self.logger.error(msg)
+            raise AttributeError(msg)
         # Start the autofocus and wait for it to completed
         kwargs['blocking'] = True
-        self._camera.autofocus(*args, **kwargs)
+        self._camera.focuser.autofocus(*args, **kwargs)
         # Find where the resulting files are. Need to cast a wide net to get both
         # coarse and fine focus files, anything in focus directory should be fair game.
         focus_path = os.path.join(os.path.abspath(self.config['directories']['images']),

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -11,7 +11,7 @@ import Pyro4
 
 from pocs.utils import load_module
 from pocs.camera import AbstractCamera
-from pocs.focuser.pyro import Focuser as PyroFocuser
+from huntsman.focuser.pyro import Focuser as PyroFocuser
 
 from huntsman.utils import load_config
 

--- a/huntsman/focuser/pyro.py
+++ b/huntsman/focuser/pyro.py
@@ -89,7 +89,7 @@ class Focuser(AbstractFocuser):
     def focuser_autofocus_keep_files(self):
         return self._proxy.focuser_autofocus_keep_files
 
-    @focuser_autofocus_keep_files
+    @focuser_autofocus_keep_files.setter
     def focuser_autofocus_keep_files(self, keep_files):
         self._proxy.focuser_autofocus_keep_files = bool(keep_files)
 
@@ -121,7 +121,7 @@ class Focuser(AbstractFocuser):
     def focuser_autofocus_mask_dilations(self):
         return self._proxy.focuser_autofocus_mask_dilations
 
-    @focuser_autofocus_mask_dilations
+    @focuser_autofocus_mask_dilations.setter
     def focuser_autofocus_mask_dilations(self, dilations):
         self._proxy.focuser_autofocus_mask_dilations = int(dilations)
 

--- a/huntsman/focuser/pyro.py
+++ b/huntsman/focuser/pyro.py
@@ -1,5 +1,7 @@
-from pocs.focuser import AbstractFocuser
+import astropy.units as u
 
+from pocs.focuser import AbstractFocuser
+from pocs.utils import get_quantity_value
 
 class Focuser(AbstractFocuser):
     """ Class representing the client side interface to the Focuser of a distributed camera. """
@@ -49,6 +51,79 @@ class Focuser(AbstractFocuser):
     @property
     def is_ready(self):
         return self._proxy.focuser_is_ready
+
+    @property
+    def focuser_autofocus_range(self):
+        return self._proxy.focuser_autofocus_range
+
+    @focuser_autofocus_range.setter
+    def focuser_autofocus_range(self, autofocus_ranges):
+        self._proxy.focuser_autofocus_range = (int(autofocus_range)
+                                               for autofocus_range in autofocus_ranges)
+
+    @property
+    def focuser_autofocus_step(self):
+        return self._proxy.focuser_autofocus_step
+
+    @focuser_autofocus_step.setter
+    def focuser_autofocus_step(self, steps):
+        self._proxy.focuser_autofocus_step = (int(step) for step in steps)
+
+    @property
+    def focuser_autofocus_seconds(self):
+        return self._proxy.focuser_autofocus_seconds
+
+    @focuser_autofocus_seconds.setter
+    def focuser_autofocus_seconds(self, seconds):
+        self._proxy.focuser_autofocus_seconds = float(get_quantity_value(seconds, u.second))
+
+    @property
+    def focuser_autofocus_size(self):
+        return self._proxy.focuser_autofocus_size
+
+    @focuser_autofocus_size.setter
+    def focuser_autofocus_size(self, size):
+        self._proxy.focuser_autofocus_size = int(size)
+
+    @property
+    def focuser_autofocus_keep_files(self):
+        return self._proxy.focuser_autofocus_keep_files
+
+    @focuser_autofocus_keep_files
+    def focuser_autofocus_keep_files(self, keep_files):
+        self._proxy.focuser_autofocus_keep_files = bool(keep_files)
+
+    @property
+    def focuser_autofocus_take_dark(self):
+        return self._proxy.focuser_autofocus_take_dark
+
+    @focuser_autofocus_take_dark.setter
+    def focuser_autofocus_take_dark(self, take_dark):
+        self._proxy.focuser_autofocus_take_dark = bool(take_dark)
+
+    @property
+    def focuser_autofocus_merit_function(self):
+        return self._proxy.focuser_autofocus_merit_function
+
+    @focuser_autofocus_merit_function.setter
+    def focuser_autofocus_merit_function(self, merit_function):
+        self._proxy.focuser_autofocus_merit_function = str(merit_function)
+
+    @property
+    def focuser_autofocus_merit_function_kwargs(self):
+        return self._proxy.focuser_autofocus_merit_function_kwargs
+
+    @focuser_autofocus_merit_function_kwargs.setter
+    def focuser_autofocus_merit_function_kwargs(self, kwargs):
+        self._proxy.focuser_autofocus_merit_function_kwargs = dict(kwargs)
+
+    @property
+    def focuser_autofocus_mask_dilations(self):
+        return self._proxy.focuser_autofocus_mask_dilations
+
+    @focuser_autofocus_mask_dilations
+    def focuser_autofocus_mask_dilations(self, dilations):
+        self._proxy.focuser_autofocus_mask_dilations = int(dilations)
 
 ##################################################################################################
 # Methods

--- a/huntsman/focuser/pyro.py
+++ b/huntsman/focuser/pyro.py
@@ -18,10 +18,6 @@ class Focuser(AbstractFocuser):
 ##################################################################################################
 
     @property
-    def is_connected(self):
-        return self._proxy.focuser_is_connected
-
-    @property
     def position(self):
         """ Current encoder position of the focuser """
         return self._proxy.focuser_position
@@ -48,77 +44,90 @@ class Focuser(AbstractFocuser):
         return self._proxy.focuser_is_moving
 
     @property
-    def focuser_autofocus_range(self):
+    def autofocus_range(self):
         return self._proxy.focuser_autofocus_range
 
-    @focuser_autofocus_range.setter
-    def focuser_autofocus_range(self, autofocus_ranges):
-        self._proxy.focuser_autofocus_range = (int(autofocus_range)
-                                               for autofocus_range in autofocus_ranges)
+    @autofocus_range.setter
+    def autofocus_range(self, autofocus_ranges):
+        if autofocus_ranges is not None:
+            autofocus_ranges = (int(autofocus_ranges[0]), int(autofocus_ranges[1]))
+        self._proxy.focuser_autofocus_range = autofocus_ranges
 
     @property
-    def focuser_autofocus_step(self):
+    def autofocus_step(self):
         return self._proxy.focuser_autofocus_step
 
-    @focuser_autofocus_step.setter
-    def focuser_autofocus_step(self, steps):
-        self._proxy.focuser_autofocus_step = (int(step) for step in steps)
+    @autofocus_step.setter
+    def autofocus_step(self, steps):
+        if steps is not None:
+            steps = (int(steps[0]), int(steps[1]))
+        self._proxy.focuser_autofocus_step = steps
 
     @property
-    def focuser_autofocus_seconds(self):
+    def autofocus_seconds(self):
         return self._proxy.focuser_autofocus_seconds
 
-    @focuser_autofocus_seconds.setter
-    def focuser_autofocus_seconds(self, seconds):
-        self._proxy.focuser_autofocus_seconds = float(get_quantity_value(seconds, u.second))
+    @autofocus_seconds.setter
+    def autofocus_seconds(self, seconds):
+        if seconds is not None:
+            seconds = float(get_quantity_value(seconds, u.second))
+        self._proxy.focuser_autofocus_seconds = seconds
 
     @property
-    def focuser_autofocus_size(self):
+    def autofocus_size(self):
         return self._proxy.focuser_autofocus_size
 
-    @focuser_autofocus_size.setter
-    def focuser_autofocus_size(self, size):
-        self._proxy.focuser_autofocus_size = int(size)
+    @autofocus_size.setter
+    def autofocus_size(self, size):
+        if size is not None:
+            size = int(size)
+        self._proxy.focuser_autofocus_size = size
 
     @property
-    def focuser_autofocus_keep_files(self):
+    def autofocus_keep_files(self):
         return self._proxy.focuser_autofocus_keep_files
 
-    @focuser_autofocus_keep_files.setter
-    def focuser_autofocus_keep_files(self, keep_files):
+    @autofocus_keep_files.setter
+    def autofocus_keep_files(self, keep_files):
         self._proxy.focuser_autofocus_keep_files = bool(keep_files)
 
     @property
-    def focuser_autofocus_take_dark(self):
+    def autofocus_take_dark(self):
         return self._proxy.focuser_autofocus_take_dark
 
-    @focuser_autofocus_take_dark.setter
-    def focuser_autofocus_take_dark(self, take_dark):
+    @autofocus_take_dark.setter
+    def autofocus_take_dark(self, take_dark):
         self._proxy.focuser_autofocus_take_dark = bool(take_dark)
 
     @property
-    def focuser_autofocus_merit_function(self):
+    def autofocus_merit_function(self):
         return self._proxy.focuser_autofocus_merit_function
 
-    @focuser_autofocus_merit_function.setter
-    def focuser_autofocus_merit_function(self, merit_function):
-        self._proxy.focuser_autofocus_merit_function = str(merit_function)
+    @autofocus_merit_function.setter
+    def autofocus_merit_function(self, merit_function):
+        if merit_function is not None:
+            merit_function = str(merit_function)
+        self._proxy.focuser_autofocus_merit_function = merit_function
 
     @property
-    def focuser_autofocus_merit_function_kwargs(self):
+    def autofocus_merit_function_kwargs(self):
         return self._proxy.focuser_autofocus_merit_function_kwargs
 
-    @focuser_autofocus_merit_function_kwargs.setter
-    def focuser_autofocus_merit_function_kwargs(self, kwargs):
-        self._proxy.focuser_autofocus_merit_function_kwargs = dict(kwargs)
+    @autofocus_merit_function_kwargs.setter
+    def autofocus_merit_function_kwargs(self, kwargs):
+        if kwargs is not None:
+            kwargs = dict(kwargs)
+        self._proxy.focuser_autofocus_merit_function_kwargs =kwargs
 
     @property
-    def focuser_autofocus_mask_dilations(self):
+    def autofocus_mask_dilations(self):
         return self._proxy.focuser_autofocus_mask_dilations
 
-    @focuser_autofocus_mask_dilations.setter
-    def focuser_autofocus_mask_dilations(self, dilations):
-        self._proxy.focuser_autofocus_mask_dilations = int(dilations)
+    @autofocus_mask_dilations.setter
+    def autofocus_mask_dilations(self, dilations):
+        if dilations is not None:
+            dilations = int(dilations)
+        self._proxy.focuser_autofocus_mask_dilations = dilations
 
 ##################################################################################################
 # Methods
@@ -131,6 +140,8 @@ class Focuser(AbstractFocuser):
         self.model = self._proxy.focuser_model
         self.port = self.camera.port
         self._serial_number = self._proxy.focuser_uid
+        self._connected = self._proxy.focuser_is_connected
+
         self.logger.debug(f"{self} connected.")
 
     def move_to(self, position):
@@ -145,3 +156,7 @@ class Focuser(AbstractFocuser):
 
     def autofocus(self, *args, **kwargs):
         self.camera.autofocus(*args, **kwargs)
+
+    def _set_autofocus_parameters(self, *args, **kwargs):
+        """Needed to stop the base class overwriting all the parameters of the remote focuser."""
+        pass

--- a/huntsman/focuser/pyro.py
+++ b/huntsman/focuser/pyro.py
@@ -1,5 +1,5 @@
 from pocs.focuser import AbstractFocuser
-from huntsman.camera.pyro import Camera as PyroCamera
+from huntsman.camera.pyro import Camera
 
 
 class Focuser(AbstractFocuser):
@@ -9,8 +9,8 @@ class Focuser(AbstractFocuser):
                  model='pyro',
                  camera=None):
 
-        if not isinstance(camera, PyroCamera):
-            msg = f"camera must be instance of huntsman.camera.pyro.Camera, got {camera}."
+        if not isinstance(camera, Camera):
+            msg = f"camera must be instance of huntsman.camera.pyro.Camera, got {type(camera)}."
             raise ValueError
 
         super().__init__(name=name, model=model, camera=camera)

--- a/huntsman/focuser/pyro.py
+++ b/huntsman/focuser/pyro.py
@@ -1,0 +1,82 @@
+from pocs.focuser import AbstractFocuser
+from huntsman.camera.pyro import Camera as PyroCamera
+
+
+class Focuser(AbstractFocuser):
+    """ Class representing the client side interface to the Focuser of a distributed camera. """
+    def __init__(self,
+                 name='Pyro Focuser',
+                 model='pyro',
+                 camera=None):
+
+        if not isinstance(camera, PyroCamera):
+            msg = f"camera must be instance of huntsman.camera.pyro.Camera, got {camera}."
+            raise ValueError
+
+        super().__init__(name=name, model=model, camera=camera)
+        self.connect()
+
+##################################################################################################
+# Properties
+##################################################################################################
+
+    @property
+    def is_connected(self):
+        """ Is the focuser available """
+        return self._proxy.focuser_is_connected
+
+    @property
+    def position(self):
+        """ Current encoder position of the focuser """
+        return self._proxy.focuser_position
+
+    @position.setter
+    def position(self, position):
+        """ Move focusser to new encoder position """
+        position = int(position)
+        self._proxy.focuser_position = position
+
+    @property
+    def min_position(self):
+        """ Get position of close limit of focus travel, in encoder units """
+        return self._proxy.focuser_min_position
+
+    @property
+    def max_position(self):
+        """ Get position of far limit of focus travel, in encoder units """
+        return self._proxy.focuser_max_position
+
+    @property
+    def is_moving(self):
+        """ True if the focuser is currently moving. """
+        return self._proxy.focuser_is_moving
+
+    @property
+    def is_ready(self):
+        return self._proxy.focuser_is_ready
+
+##################################################################################################
+# Methods
+##################################################################################################
+
+    def connect(self):
+        # Pyro4 proxy to remote huntsman.camera.pyro.CameraServer instance.
+        self._proxy = self.camera._proxy
+        self.name = self._proxy.focuser_name
+        self.model = self._proxy.focuser_model
+        self.port = self.camera.port
+        self._serial_number = self._proxy.focuser_uid
+        self.logger.debug(f"{self} connected.")
+
+    def move_to(self, position):
+        """ Move focuser to new encoder position """
+        position = int(position)
+        return self._proxy.focuser_move_to(position)
+
+    def move_by(self, increment):
+        """ Move focuser by a given amount """
+        increment = int(increment)
+        return self._proxy.focuser_move_by(increment)
+
+    def autofocus(self, *args, **kwargs):
+        self.camera.autofocus(*args, **kwargs)

--- a/huntsman/focuser/pyro.py
+++ b/huntsman/focuser/pyro.py
@@ -19,7 +19,6 @@ class Focuser(AbstractFocuser):
 
     @property
     def is_connected(self):
-        """ Is the focuser available """
         return self._proxy.focuser_is_connected
 
     @property
@@ -47,10 +46,6 @@ class Focuser(AbstractFocuser):
     def is_moving(self):
         """ True if the focuser is currently moving. """
         return self._proxy.focuser_is_moving
-
-    @property
-    def is_ready(self):
-        return self._proxy.focuser_is_ready
 
     @property
     def focuser_autofocus_range(self):

--- a/huntsman/focuser/pyro.py
+++ b/huntsman/focuser/pyro.py
@@ -1,5 +1,4 @@
 from pocs.focuser import AbstractFocuser
-from huntsman.camera.pyro import Camera
 
 
 class Focuser(AbstractFocuser):
@@ -8,10 +7,6 @@ class Focuser(AbstractFocuser):
                  name='Pyro Focuser',
                  model='pyro',
                  camera=None):
-
-        if not isinstance(camera, Camera):
-            msg = f"camera must be instance of huntsman.camera.pyro.Camera, got {type(camera)}."
-            raise ValueError
 
         super().__init__(name=name, model=model, camera=camera)
         self.connect()

--- a/huntsman/tests/test_camera.py
+++ b/huntsman/tests/test_camera.py
@@ -11,6 +11,7 @@ import sys
 import astropy.units as u
 
 import Pyro4
+import Pyro4.util
 
 from pocs.scheduler.field import Field
 from pocs.scheduler.observation import Observation
@@ -37,7 +38,7 @@ def camera(request, images_dir, camera_server):
         ns = Pyro4.locateNS()
         cameras = ns.list(metadata_all={'POCS', 'Camera'})
         cam_name, cam_uri = cameras.popitem()
-        camera = PyroCamera(name=cam_name, uri=cam_uri)
+        camera = PyroCamera(port=cam_name, uri=cam_uri)
 
     camera.config['directories']['images'] = images_dir
     return camera

--- a/huntsman/tests/test_camera.py
+++ b/huntsman/tests/test_camera.py
@@ -162,10 +162,7 @@ def test_exposure(camera, tmpdir):
     assert not exp_event.is_set()
     assert not camera.is_ready
     # By default take_exposure is non-blocking, need to give it some time to complete.
-    if isinstance(camera, FLICamera):
-        time.sleep(10)
-    else:
-        time.sleep(5)
+    time.sleep(5)
     # Output file should exist, Event should be set and camera should say it's not exposing.
     assert os.path.exists(fits_path)
     assert exp_event.is_set()

--- a/huntsman/tests/test_camera.py
+++ b/huntsman/tests/test_camera.py
@@ -16,7 +16,7 @@ import Pyro4.util
 from pocs.scheduler.field import Field
 from pocs.scheduler.observation import Observation
 from pocs.utils.images import fits as fits_utils
-from pocs import error
+from pocs.utils import error
 
 from huntsman.camera.pyro import Camera as PyroCamera
 

--- a/huntsman/tests/test_camera.py
+++ b/huntsman/tests/test_camera.py
@@ -67,6 +67,17 @@ def test_init(camera):
     assert camera.is_connected
 
 
+def test_init(camera):
+    """
+    Test that camera got initialised as expected
+    """
+    assert camera.is_connected
+
+    if isinstance(camera, SBIGCamera):
+        # Successfully initialised SBIG cameras should also have a valid 'handle'
+        assert camera._handle != INVALID_HANDLE_VALUE
+
+
 def test_uid(camera):
     # Camera uid should be a string (or maybe an int?) of non-zero length. Assert True
     assert camera.uid
@@ -81,40 +92,68 @@ def test_get_temp(camera):
         assert temperature is not None
 
 
-def test_set_set_point(camera):
-    try:
-        camera.target_temperature = 10 * u.Celsius
-    except NotImplementedError:
-        pytest.skip("Camera {} doesn't implement temperature control".format(camera.name))
+def test_is_cooled(camera):
+    cooled_camera = camera.is_cooled_camera
+    assert cooled_camera is not None
+
+
+def test_set_target_temperature(camera):
+    if camera.is_cooled_camera:
+        camera._target_temperature = 10 * u.Celsius
+        assert abs(camera._target_temperature - 10 * u.Celsius) < 0.5 * u.Celsius
     else:
-        assert abs(camera.target_temperature - 10 * u.Celsius) < 0.5 * u.Celsius
+        pytest.skip("Camera {} doesn't implement temperature control".format(camera.name))
+
+
+def test_cooling_enabled(camera):
+    cooling_enabled = camera.cooling_enabled
+    if not camera.is_cooled_camera:
+        assert not cooling_enabled
 
 
 def test_enable_cooling(camera):
-    try:
+    if camera.is_cooled_camera:
         camera.cooling_enabled = True
-    except NotImplementedError:
-        pytest.skip("Camera {} doesn't implement control of cooling status".format(camera.name))
+        assert camera.cooling_enabled
     else:
-        assert camera.cooling_enabled is True
+        pytest.skip("Camera {} doesn't implement control of cooling status".format(camera.name))
 
 
 def test_get_cooling_power(camera):
-    try:
+    if camera.is_cooled_camera:
         power = camera.cooling_power
-    except NotImplementedError:
-        pytest.skip("Camera {} doesn't implement cooling power readout".format(camera.name))
-    else:
         assert power is not None
+    else:
+        pytest.skip("Camera {} doesn't implement cooling power readout".format(camera.name))
 
 
 def test_disable_cooling(camera):
-    try:
+    if camera.is_cooled_camera:
         camera.cooling_enabled = False
-    except NotImplementedError:
-        pytest.skip("Camera {} doesn't implement control of cooling status".format(camera.name))
+        assert not camera.cooling_enabled
     else:
-        assert camera.cooling_enabled is False
+        pytest.skip("Camera {} doesn't implement control of cooling status".format(camera.name))
+
+
+def test_temperature_tolerance(camera):
+    temp_tol = camera.temperature_tolerance
+    camera.temperature_tolerance = temp_tol.value + 1
+    assert camera.temperature_tolerance == temp_tol + 1 * u.Celsius
+    camera.temperature_tolerance = temp_tol
+    assert camera.temperature_tolerance == temp_tol
+
+
+def test_is_temperature_stable(camera):
+    if camera.is_cooled_camera:
+        camera.target_temperature = camera.temperature
+        camera.cooling_enabled = True
+        time.sleep(1)
+        assert camera.is_temperature_stable
+        camera.cooling_enabled = False
+        assert not camera.is_temperature_stable
+        camera.cooling_enabled = True
+    else:
+        assert not camera.is_temperature_stable
 
 
 def test_exposure(camera, tmpdir):
@@ -122,12 +161,26 @@ def test_exposure(camera, tmpdir):
     Tests basic take_exposure functionality
     """
     fits_path = str(tmpdir.join('test_exposure.fits'))
+    if camera.is_cooled_camera and camera.cooling_enabled is False:
+        camera.cooling_enabled = True
+        time.sleep(5)  # Give camera time to cool
+    assert camera.is_ready
+    assert not camera.is_exposing
     # A one second normal exposure.
-    camera.logger.debug(f'test_exposure fits_path={fits_path}')
-    camera.take_exposure(filename=fits_path)
+    exp_event = camera.take_exposure(filename=fits_path)
+    assert camera.is_exposing
+    assert not exp_event.is_set()
+    assert not camera.is_ready
     # By default take_exposure is non-blocking, need to give it some time to complete.
-    time.sleep(5)
+    if isinstance(camera, FLICamera):
+        time.sleep(10)
+    else:
+        time.sleep(5)
+    # Output file should exist, Event should be set and camera should say it's not exposing.
     assert os.path.exists(fits_path)
+    assert exp_event.is_set()
+    assert not camera.is_exposing
+    assert camera.is_ready
     # If can retrieve some header data there's a good chance it's a valid FITS file
     header = fits_utils.getheader(fits_path)
     assert header['EXPTIME'] == 1.0
@@ -172,12 +225,34 @@ def test_exposure_collision(camera, tmpdir):
     fits_path_1 = str(tmpdir.join('test_exposure_collision1.fits'))
     fits_path_2 = str(tmpdir.join('test_exposure_collision2.fits'))
     camera.take_exposure(2 * u.second, filename=fits_path_1)
-    camera.take_exposure(1 * u.second, filename=fits_path_2)
-    time.sleep(5)
+    with pytest.raises(error.PanError):
+        camera.take_exposure(1 * u.second, filename=fits_path_2)
+    if isinstance(camera, FLICamera):
+        time.sleep(10)
+    else:
+        time.sleep(5)
     assert os.path.exists(fits_path_1)
-    assert os.path.exists(fits_path_2)
+    assert not os.path.exists(fits_path_2)
     assert fits_utils.getval(fits_path_1, 'EXPTIME') == 2.0
-    assert fits_utils.getval(fits_path_2, 'EXPTIME') == 1.0
+
+
+def test_exposure_scaling(camera, tmpdir):
+    """Regression test for incorrect pixel value scaling.
+
+    Checks for zero padding of LSBs instead of MSBs, as encountered
+    with ZWO ASI cameras.
+    """
+    try:
+        bit_depth = camera.bit_depth
+    except NotImplementedError:
+        pytest.skip("Camera does not have bit_depth attribute")
+    else:
+        fits_path = str(tmpdir.join('test_exposure_scaling.fits'))
+        camera.take_exposure(filename=fits_path, dark=True, blocking=True)
+        image_data, image_header = fits.getdata(fits_path, header=True)
+        assert bit_depth == image_header['BITDEPTH'] * u.bit
+        pad_bits = image_header['BITPIX'] - image_header['BITDEPTH']
+        assert (image_data % 2**pad_bits).any()
 
 
 def test_exposure_no_filename(camera):
@@ -192,6 +267,46 @@ def test_exposure_not_connected(camera):
     camera._connected = True
 
 
+def test_exposure_moving(camera, tmpdir):
+    if not camera.filterwheel:
+        pytest.skip("Camera does not have a filterwheel")
+    fits_path_1 = str(tmpdir.join('test_not_moving.fits'))
+    fits_path_2 = str(tmpdir.join('test_moving.fits'))
+    camera.filterwheel.position = 1
+    exp_event = camera.take_exposure(filename=fits_path_1)
+    exp_event.wait()
+    assert os.path.exists(fits_path_1)
+    move_event = camera.filterwheel.move_to(2)
+    with pytest.raises(error.PanError):
+        camera.take_exposure(filename=fits_path_2)
+    move_event.wait()
+    assert not os.path.exists(fits_path_2)
+
+
+def test_exposure_timeout(camera, tmpdir, caplog):
+    """
+    Tests response to an exposure timeout
+    """
+    fits_path = str(tmpdir.join('test_exposure_timeout.fits'))
+    # Make timeout extremely short to force a timeout error
+    original_timeout = camera._timeout
+    camera._timeout = 0.01
+    # This should result in a timeout error in the poll thread, but the exception won't
+    # be seen in the main thread. Can check for logged error though.
+    exposure_event = camera.take_exposure(seconds=0.1, filename=fits_path)
+    # Wait for it all to be over.
+    time.sleep(original_timeout)
+    # Put the timeout back to the original setting.
+    camera._timeout = original_timeout
+    # Should be an ERROR message in the log from the exposure tiemout
+    assert caplog.records[-1].levelname == "ERROR"
+    # Should be no data file, camera should not be exposing, and exposure event should be set
+    assert not os.path.exists(fits_path)
+    assert not camera.is_exposing
+    assert exposure_event is camera._exposure_event
+    assert exposure_event.is_set()
+
+
 def test_observation(camera, images_dir):
     """
     Tests functionality of take_observation()
@@ -203,11 +318,12 @@ def test_observation(camera, images_dir):
     time.sleep(7)
     observation_pattern = os.path.join(images_dir, 'fields', 'TestObservation',
                                        camera.uid, observation.seq_time, '*.fits*')
-    camera.logger.debug(f'Looking for observation pattern: {observation_pattern}')
     assert len(glob.glob(observation_pattern)) == 1
 
 
 def test_autofocus_coarse(camera, patterns, counter):
+    if not camera.focuser:
+        pytest.skip("Camera does not have a focuser")
     autofocus_event = camera.autofocus(coarse=True)
     autofocus_event.wait()
     counter['value'] += 1
@@ -215,6 +331,8 @@ def test_autofocus_coarse(camera, patterns, counter):
 
 
 def test_autofocus_fine(camera, patterns, counter):
+    if not camera.focuser:
+        pytest.skip("Camera does not have a focuser")
     autofocus_event = camera.autofocus()
     autofocus_event.wait()
     counter['value'] += 1
@@ -222,6 +340,8 @@ def test_autofocus_fine(camera, patterns, counter):
 
 
 def test_autofocus_fine_blocking(camera, patterns, counter):
+    if not camera.focuser:
+        pytest.skip("Camera does not have a focuser")
     autofocus_event = camera.autofocus(blocking=True)
     assert autofocus_event.is_set()
     counter['value'] += 1
@@ -229,6 +349,8 @@ def test_autofocus_fine_blocking(camera, patterns, counter):
 
 
 def test_autofocus_with_plots(camera, patterns, counter):
+    if not camera.focuser:
+        pytest.skip("Camera does not have a focuser")
     autofocus_event = camera.autofocus(make_plots=True)
     autofocus_event.wait()
     counter['value'] += 1
@@ -237,15 +359,18 @@ def test_autofocus_with_plots(camera, patterns, counter):
 
 
 def test_autofocus_coarse_with_plots(camera, patterns, counter):
+    if not camera.focuser:
+        pytest.skip("Camera does not have a focuser")
     autofocus_event = camera.autofocus(coarse=True, make_plots=True)
     autofocus_event.wait()
     counter['value'] += 1
     assert len(glob.glob(patterns['final'])) == counter['value']
-    assert len(glob.glob(patterns['fine_plot'])) == 1
     assert len(glob.glob(patterns['coarse_plot'])) == 1
 
 
 def test_autofocus_keep_files(camera, patterns, counter):
+    if not camera.focuser:
+        pytest.skip("Camera does not have a focuser")
     autofocus_event = camera.autofocus(keep_files=True)
     autofocus_event.wait()
     counter['value'] += 1

--- a/huntsman/tests/test_camera.py
+++ b/huntsman/tests/test_camera.py
@@ -16,6 +16,7 @@ import Pyro4.util
 from pocs.scheduler.field import Field
 from pocs.scheduler.observation import Observation
 from pocs.utils.images import fits as fits_utils
+from pocs import error
 
 from huntsman.camera.pyro import Camera as PyroCamera
 

--- a/huntsman/tests/test_camera.py
+++ b/huntsman/tests/test_camera.py
@@ -218,6 +218,7 @@ def test_exposure_collision(camera, tmpdir):
     assert os.path.exists(fits_path_1)
     assert not os.path.exists(fits_path_2)
     assert fits_utils.getval(fits_path_1, 'EXPTIME') == 2.0
+    assert not camera.is_exposing
 
 
 def test_exposure_scaling(camera, tmpdir):

--- a/huntsman/tests/test_camera.py
+++ b/huntsman/tests/test_camera.py
@@ -67,17 +67,6 @@ def test_init(camera):
     assert camera.is_connected
 
 
-def test_init(camera):
-    """
-    Test that camera got initialised as expected
-    """
-    assert camera.is_connected
-
-    if isinstance(camera, SBIGCamera):
-        # Successfully initialised SBIG cameras should also have a valid 'handle'
-        assert camera._handle != INVALID_HANDLE_VALUE
-
-
 def test_uid(camera):
     # Camera uid should be a string (or maybe an int?) of non-zero length. Assert True
     assert camera.uid

--- a/huntsman/tests/test_camera.py
+++ b/huntsman/tests/test_camera.py
@@ -371,7 +371,7 @@ def test_autofocus_keep_files(camera, patterns, counter):
     assert len(glob.glob(patterns['final'])) == counter['value']
 
 
-def test_autofocus_no_size(camera):
+def test_autofocus_no_size(camera, caplog):
     try:
         initial_focus = camera.focuser.position
     except AttributeError:
@@ -379,13 +379,16 @@ def test_autofocus_no_size(camera):
     initial_focus = camera.focuser.position
     thumbnail_size = camera.focuser.autofocus_size
     camera.focuser.autofocus_size = None
-    with pytest.raises(ValueError):
-        camera.autofocus()
+    camera.autofocus()
+    # Will be an ValueError raised, but it's hidden in another thread.
+    # Should be an error in the logs, though.
+    time.sleep(0.1)
+    assert caplog.records[-1].levelname == "ERROR"
     camera.focuser.autofocus_size = thumbnail_size
     assert camera.focuser.position == initial_focus
 
 
-def test_autofocus_no_seconds(camera):
+def test_autofocus_no_seconds(camera, caplog):
     try:
         initial_focus = camera.focuser.position
     except AttributeError:
@@ -393,13 +396,16 @@ def test_autofocus_no_seconds(camera):
     initial_focus = camera.focuser.position
     seconds = camera.focuser.autofocus_seconds
     camera.focuser.autofocus_seconds = None
-    with pytest.raises(ValueError):
-        camera.autofocus()
+    camera.autofocus()
+    # Will be an ValueError raise, but it's hidden in another thread.
+    # Should be an error in the logs, though.
+    time.sleep(0.1)
+    assert caplog.records[-1].levelname == "ERROR"
     camera.focuser.autofocus_seconds = seconds
     assert camera.focuser.position == initial_focus
 
 
-def test_autofocus_no_step(camera):
+def test_autofocus_no_step(camera, caplog):
     try:
         initial_focus = camera.focuser.position
     except AttributeError:
@@ -407,13 +413,16 @@ def test_autofocus_no_step(camera):
     initial_focus = camera.focuser.position
     autofocus_step = camera.focuser.autofocus_step
     camera.focuser.autofocus_step = None
-    with pytest.raises(ValueError):
-        camera.autofocus()
+    camera.autofocus()
+    # Will be an ValueError raise, but it's hidden in another thread.
+    # Should be an error in the logs, though.
+    time.sleep(0.1)
+    assert caplog.records[-1].levelname == "ERROR"
     camera.focuser.autofocus_step = autofocus_step
     assert camera.focuser.position == initial_focus
 
 
-def test_autofocus_no_range(camera):
+def test_autofocus_no_range(camera, caplog):
     try:
         initial_focus = camera.focuser.position
     except AttributeError:
@@ -421,8 +430,11 @@ def test_autofocus_no_range(camera):
     initial_focus = camera.focuser.position
     autofocus_range = camera.focuser.autofocus_range
     camera.focuser.autofocus_range = None
-    with pytest.raises(ValueError):
-        camera.autofocus()
+    camera.autofocus()
+    # Will be an ValueError raise, but it's hidden in another thread.
+    # Should be an error in the logs, though.
+    time.sleep(0.1)
+    assert caplog.records[-1].levelname == "ERROR"
     camera.focuser.autofocus_range = autofocus_range
     assert camera.focuser.position == initial_focus
 

--- a/huntsman/tests/test_camera.py
+++ b/huntsman/tests/test_camera.py
@@ -214,10 +214,7 @@ def test_exposure_collision(camera, tmpdir):
     camera.take_exposure(2 * u.second, filename=fits_path_1)
     with pytest.raises(error.PanError):
         camera.take_exposure(1 * u.second, filename=fits_path_2)
-    if isinstance(camera, FLICamera):
-        time.sleep(10)
-    else:
-        time.sleep(5)
+    time.sleep(5)
     assert os.path.exists(fits_path_1)
     assert not os.path.exists(fits_path_2)
     assert fits_utils.getval(fits_path_1, 'EXPTIME') == 2.0


### PR DESCRIPTION
Adds a Pyro `Focuser` class to provide a functional `.focuser` attribute for the client side Pyro `Camera` class in order to enable direct access to remote focusers and fix #115.