### PR TITLE
Don't block in calibrating state if using 'night' simulator

### DIFF
--- a/states/huntsman/calibrating.py
+++ b/states/huntsman/calibrating.py
@@ -33,12 +33,18 @@ def wait_for_sun_alt(pocs,
         delay = pocs._safe_delay
 
     while pocs.is_safe():
+
         sun_pos = pocs.observatory.observer.altaz(current_time(),
                                                   target=get_sun(current_time())
                                                   ).alt
         if sun_pos.value > max_altitude or sun_pos.value < min_altitude:
-            pocs.say(message.format(sun_pos.value))
-            pocs.sleep(delay=delay)
+            # Check simulator for 'night'
+            if 'night' in pocs.config['simulator']:
+                pocs.logger.info(f'Using night simulator, pretending sun up.')
+                break
+            else:
+                pocs.say(message.format(sun_pos.value))
+                pocs.sleep(delay=delay)
         else:
             break
 

--- a/states/huntsman/calibrating.py
+++ b/states/huntsman/calibrating.py
@@ -33,7 +33,6 @@ def wait_for_sun_alt(pocs,
         delay = pocs._safe_delay
 
     while pocs.is_safe():
-
         sun_pos = pocs.observatory.observer.altaz(current_time(),
                                                   target=get_sun(current_time())
                                                   ).alt

--- a/states/huntsman/calibrating.py
+++ b/states/huntsman/calibrating.py
@@ -39,7 +39,7 @@ def wait_for_sun_alt(pocs,
         if sun_pos.value > max_altitude or sun_pos.value < min_altitude:
             # Check simulator for 'night'
             if 'night' in pocs.config['simulator']:
-                pocs.logger.info(f'Using night simulator, pretending sun up.')
+                pocs.logger.info(f'Using night simulator, pretending sun down.')
                 break
             else:
                 pocs.say(message.format(sun_pos.value))


### PR DESCRIPTION
This check could feasibly happen earlier in the code block but I wanted to maintain some of the coverage in the event that the `night` simulator is being used. 

Closes #114 