### PR TITLE
Adding tags to states and fixing IERS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ before_install:
   - cd POCS
   - pip install -r requirements.txt
   - python setup.py install
-  # Download the astrometry.net files and IERS index.
-  - python pocs/utils/data.py --folder $PANDIR/astrometry/data
+  # Download just the IERS index.
+  - python pocs/utils/data.py --no-narrow-field --no-wide-field
   # Create SSH key for Pyro nameservers
   - ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -N ''
   - touch ~/.ssh/authorized_keys

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,14 @@ before_install:
   - cd POCS
   - pip install -r requirements.txt
   - python setup.py install
+  # Create SSH key for Pyro nameservers
+  - ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -N ''
+  - touch ~/.ssh/authorized_keys
+  - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+  - ssh-keyscan -H localhost >> ~/.ssh/known_hosts
+install:
+  - cd $TRAVIS_BUILD_DIR
+  - pip install -r requirements.txt
   # Download just the IERS index.
   - |
     echo "\
@@ -32,14 +40,6 @@ before_install:
     iers_auto_url_mirror = https://storage.googleapis.com/panoptes-resources/iers/ser7.dat
     " >> $HOME/.astropy/config/astropy.cfg
   - python pocs/utils/data.py --no-narrow-field --no-wide-field
-  # Create SSH key for Pyro nameservers
-  - ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -N ''
-  - touch ~/.ssh/authorized_keys
-  - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-  - ssh-keyscan -H localhost >> ~/.ssh/known_hosts
-install:
-  - cd $TRAVIS_BUILD_DIR
-  - pip install -r requirements.txt
   - python setup.py install
 script:
   - export PYTHONPATH="$PYTHONPATH:$POCS/scripts/coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,22 @@ cache:
 env:
   - PANDIR=/var/huntsman POCS=${PANDIR}/POCS PANUSER=$USER HUNTSMAN_POCS=${PANDIR}/huntsman-pocs
 before_install:
+  # Set up directories.
   - sudo mkdir $PANDIR && sudo chmod 777 $PANDIR
   - mkdir -p $PANDIR/logs
+  - ln -s $TRAVIS_BUILD_DIR $PANDIR/huntsman-pocs
+  # Install testing dependencies.
   - pip install -U pip
   - pip install coveralls
   - cd $PANDIR
+  # Install POCS
   - git clone https://github.com/panoptes/POCS.git
   - cd POCS
   - pip install -r requirements.txt
   - python setup.py install
-  - ln -s $TRAVIS_BUILD_DIR $PANDIR/huntsman-pocs
+  # Download the astrometry.net files and IERS index.
+  - python pocs/utils/data.py --folder $PANDIR/astrometry/data
+  # Create SSH key for Pyro nameservers
   - ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -N ''
   - touch ~/.ssh/authorized_keys
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,13 @@ before_install:
   - pip install -r requirements.txt
   - python setup.py install
   # Download just the IERS index.
+  - |
+    echo "\
+
+    [utils.iers.iers]
+    iers_auto_url = https://storage.googleapis.com/panoptes-resources/iers/ser7.dat
+    iers_auto_url_mirror = https://storage.googleapis.com/panoptes-resources/iers/ser7.dat
+    " >> $HOME/.astropy/config/astropy.cfg
   - python pocs/utils/data.py --no-narrow-field --no-wide-field
   # Create SSH key for Pyro nameservers
   - ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -N ''

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
     iers_auto_url_mirror = https://storage.googleapis.com/panoptes-resources/iers/ser7.dat
     " >> $HOME/.astropy/config/astropy.cfg
   # Download just the IERS index.
-  - python pocs/utils/data.py --no-narrow-field --no-wide-field
+  - python $POCS/pocs/utils/data.py --no-narrow-field --no-wide-field
   - python setup.py install
 script:
   - export PYTHONPATH="$PYTHONPATH:$POCS/scripts/coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,9 @@ before_install:
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt
-  # Download just the IERS index.
+  # Dummy command to make astropy config file appear.
+  - python -c "import astroplan"
+  # Add custom IERS urls to astropy config.
   - |
     echo "\
 
@@ -39,6 +41,7 @@ install:
     iers_auto_url = https://storage.googleapis.com/panoptes-resources/iers/ser7.dat
     iers_auto_url_mirror = https://storage.googleapis.com/panoptes-resources/iers/ser7.dat
     " >> $HOME/.astropy/config/astropy.cfg
+  # Download just the IERS index.
   - python pocs/utils/data.py --no-narrow-field --no-wide-field
   - python setup.py install
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -e git+git://github.com/AstroHuntsman/gunagala@master#egg=gunagala
 -e git+git://github.com/panoptes/POCS@develop#egg=panoptes
-astroplan
-astropy >= 2.0.0
+-e git+git://github.com/astropy/astroplan@master#egg=astroplan
+astropy >= 3.2.3
 astroquery
 ccdproc
 codecov

--- a/resources/state_table/huntsman.yaml
+++ b/resources/state_table/huntsman.yaml
@@ -3,19 +3,26 @@ name: huntsman
 initial: sleeping
 location: states
 states:
-    - parked
-    - sleeping
-    - housekeeping
-    - ready
-    - calibrating
-    - scheduling
-    - preparing
-    - slewing
-    - focusing
-    - observing
-    - analyzing
-    - dithering
-    - parking
+    parked:
+        tags: always_safe
+    sleeping:
+        tags: always_safe
+    housekeeping:
+        tags: always_safe
+    ready:
+        tags: always_safe
+    calibrating:
+        tags: at_twilight
+    scheduling:
+        tags: always_safe
+    preparing:
+    slewing:
+    focusing:
+    observing:
+    analyzing:
+    dithering:
+    parking:
+        tags: always_safe
 transitions:
     -
         source:
@@ -46,12 +53,12 @@ transitions:
         source: housekeeping
         dest: ready
         trigger: get_ready
-        conditions: mount_is_initialized 
+        conditions: mount_is_initialized
     -
         source: sleeping
         dest: ready
         trigger: get_ready
-        conditions: mount_is_initialized 
+        conditions: mount_is_initialized
     -
         source: ready
         dest: calibrating
@@ -59,7 +66,7 @@ transitions:
     -
         source: ready
         dest: scheduling
-        trigger: schedule        
+        trigger: schedule
     -
         source: calibrating
         dest: scheduling

--- a/resources/state_table/huntsman.yaml
+++ b/resources/state_table/huntsman.yaml
@@ -3,6 +3,8 @@ name: huntsman
 initial: sleeping
 location: states
 states:
+    parking:
+        tags: always_safe
     parked:
         tags: always_safe
     sleeping:
@@ -11,18 +13,17 @@ states:
         tags: always_safe
     ready:
         tags: always_safe
-    calibrating:
-        tags: at_twilight
     scheduling:
         tags: always_safe
+    calibrating:
+        tags: at_twilight
+    focusing:
+        tags: at_twilight
     preparing:
     slewing:
-    focusing:
     observing:
     analyzing:
     dithering:
-    parking:
-        tags: always_safe
 transitions:
     -
         source:


### PR DESCRIPTION
* Adding state tags for safety and twilight.
  * Closes #124 after panoptes/POCS#930
* Use the development version of astroplan and the latest version of astropy so that we have respect for the IERS urls.

