### PR TITLE
Fix exposure

### DIFF
--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -212,11 +212,14 @@ class Camera(AbstractCamera):
 
         # Start the exposure
         filename = os.path.abspath(filename) 
-        base_name = os.path.split(filename)[-1]
+        dir_name, base_name = os.path.split(filename)
+        
         self.logger.debug(f'Taking {seconds} second exposure on {self.name}: {base_name}')
+        
         # Remote method call to start the exposure
         exposure_result = self._proxy.take_exposure(seconds=seconds,
                                                     base_name=base_name,
+                                                    dir_name=dir_name,
                                                     dark=bool(dark),
                                                     *args,
                                                     **kwargs) 
@@ -570,11 +573,17 @@ class CameraServer(object):
         """
         return self._camera.uid
 
-    def take_exposure(self, seconds, base_name, dark, *args, **kwargs):
+    def take_exposure(self, seconds, base_name, dark, dir_name=None, *args,
+                      **kwargs):
         
         #Specify the full filename
-        filename = os.path.join(os.path.abspath(
+        #This uses the camera server's "images" directory 
+        if dir_name is None:
+            filename = os.path.join(os.path.abspath(
                         self.config['directories']['images']), base_name)
+        #This does not necessarily use the "images" directory
+        else:
+            filename = os.path.join(dir_name, base_name)
                     
         #Start the exposure and wait for it complete
         self._camera.take_exposure(seconds=seconds,

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -124,16 +124,19 @@ class Camera(AbstractCamera):
         '''
         # Make sure there isn't an exposure already in progress.
         if self.is_exposing:
+            self.logger.debug('Camera not ready: exposing!')
             return False
         
         # For cooled camera expect stable temperature before taking exposure
         if self.is_cooled_camera and not self.is_temperature_stable:
+            self.logger.debug('Camera not ready: temperature not stable!')
             return False
 
         # Check all the subcomponents too, e.g. make sure filterwheel/focuser 
         #aren't moving.
         for sub_name in self._subcomponent_names:
             if getattr(self, sub_name) and not getattr(self,sub_name).is_ready:
+                self.logger.debug(f'Camera not ready: {sub_name} not ready!')
                 return False
 
         return True

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -212,14 +212,11 @@ class Camera(AbstractCamera):
 
         # Start the exposure
         filename = os.path.abspath(filename) 
-        dir_name, base_name = os.path.split(filename)
-        
+        base_name = os.path.split(filename)[-1]
         self.logger.debug(f'Taking {seconds} second exposure on {self.name}: {base_name}')
-        
         # Remote method call to start the exposure
         exposure_result = self._proxy.take_exposure(seconds=seconds,
                                                     base_name=base_name,
-                                                    dir_name=dir_name,
                                                     dark=bool(dark),
                                                     *args,
                                                     **kwargs) 
@@ -573,17 +570,11 @@ class CameraServer(object):
         """
         return self._camera.uid
 
-    def take_exposure(self, seconds, base_name, dark, dir_name=None, *args,
-                      **kwargs):
+    def take_exposure(self, seconds, base_name, dark, *args, **kwargs):
         
         #Specify the full filename
-        #This uses the camera server's "images" directory 
-        if dir_name is None:
-            filename = os.path.join(os.path.abspath(
+        filename = os.path.join(os.path.abspath(
                         self.config['directories']['images']), base_name)
-        #This does not necessarily use the "images" directory
-        else:
-            filename = os.path.join(dir_name, base_name)
                     
         #Start the exposure and wait for it complete
         self._camera.take_exposure(seconds=seconds,


### PR DESCRIPTION
Quick fix for the (currently failing) test_exposure:

- Overrides is_ready in pyro.camera

- Checks is_exposing before any thing else in is_ready. This allows is_ready to behave as expected when an exposure is already in progress by bypassing the rest of the check. 

- For some reason, the other checks seemed to cause the is_ready method to wait until the exposure was completed previously. I do not have a clear idea about why this is, but is_temperature_stable may be the culprit...