### PR TITLE
NGAS push

### DIFF
--- a/conf_files/huntsman.yaml
+++ b/conf_files/huntsman.yaml
@@ -58,7 +58,7 @@ pointing:
 messaging:
     cmd_port: 6500
     msg_port: 6510
-    ngas_server_ip: 127.0.0.1 #This should be updated in huntsman_local.yaml
+    huntsman_pro_ip: 127.0.0.1 #This should be updated in huntsman_local.yaml
 state_machine: /var/huntsman/huntsman-pocs/resources/state_table/huntsman.yaml
 
 ########################### Flat Fields ########################################

--- a/conf_files/huntsman.yaml
+++ b/conf_files/huntsman.yaml
@@ -58,6 +58,7 @@ pointing:
 messaging:
     cmd_port: 6500
     msg_port: 6510
+    ngas_server_ip: 127.0.0.1 #This should be updated in huntsman_local.yaml
 state_machine: /var/huntsman/huntsman-pocs/resources/state_table/huntsman.yaml
 
 ########################### Flat Fields ########################################

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -216,7 +216,7 @@ class Camera(AbstractCamera):
             dark (bool, optional): Exposure is a dark frame (don't open shutter), default False
             blocking (bool, optional): If False (default) returns immediately after starting
                 the exposure, if True will block until it completes.
-            ngas_push (bool, optional): Push file to NGAS database?
+            ngas_push (bool, optional): Push file to NGAS database? Default is False.
 
         Returns:
             threading.Event: Event that will be set when exposure is complete
@@ -499,8 +499,7 @@ class Camera(AbstractCamera):
         return result
     
     
-    def _NGASpush(self, filename, filename_ngas=None, ngas_push=True,
-                  port=7778):
+    def _NGASpush(self, filename, filename_ngas, ngas_push=True, port=7778):
         '''
         Parameters
         ----------
@@ -521,10 +520,14 @@ class Camera(AbstractCamera):
         '''
         if not ngas_push: #No need to do anything
             return True
-                
-        if filename_ngas is None:
-            filename_ngas = os.path.basename(filename)
         
+        #Make sure a valid filename is given
+        try:
+            assert(type(filename_ngas)==str)
+        except AssertionError as e:
+            self.logger.error('NGAS filename needs to be specified for NGAS push.')
+            raise e
+                                    
         #Get the IP address of the NGAS server
         ngas_ip = self.config['messaging']['ngas_server_ip']
         
@@ -589,10 +592,7 @@ class Camera(AbstractCamera):
             
             #Replace slashes by underscores
             filename_ngas = filename_ngas[1:].replace(os.sep, '_')
-            
-            self.logger.debug(file_path)
-            self.logger.debug(filename_ngas)
-                    
+                                
         #Take the exposure, passing the NGAS filename
         exposure_event = self.take_exposure(seconds=exptime,filename=file_path,
                                             filename_ngas=filename_ngas,

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -489,14 +489,14 @@ class Camera(AbstractCamera):
         return result
     
 
-    def _process_fits(self, file_path, info, *args, **kwargs):
+    def _process_fits(self, file_path, info):
         '''
         Override _process_fits, called by process_exposure in take_observation.
         
         The difference is that we do an NGAS push following the processing.
         '''
         #Call the super method
-        result = super()._process_fits(file_path, info, *args, **kwargs)
+        result = super()._process_fits(file_path, info)
         
         #Do the NGAS push
         self._NGASpush(file_path, info)
@@ -511,6 +511,8 @@ class Camera(AbstractCamera):
         filename (str):
             The local filename, the basename of which is the default NGAS
             filename.
+        metadata:
+            A dict-like object containing metadata to build the NGAS filename.
         filename_ngas (str, optional):
             The NGAS filename. If None, auto-assign based on filename.
         port (int, optional):
@@ -669,8 +671,6 @@ class CameraServer(object):
                                    blocking=True,
                                    *args,
                                    **kwargs)
-        return filename
-
 
     def autofocus(self, *args, **kwargs):
         if not self.has_focuser:


### PR DESCRIPTION
Modified Camera in pyro.py to perform NGAS push following a successful call to take_exposure.

- By default, take_exposure does not attempt an NGAS push.

- By default, take_observation does attempt the NGAS push and specifies the NGAS filename as the collapsed filename defined in _setup_observation.

- Similar functionality also needs to be added for calibration exposures, but not autofocus ones.

Let me know what you think!