### PR TITLE
fix typo in calibrating state

### DIFF
--- a/states/huntsman/calibrating.py
+++ b/states/huntsman/calibrating.py
@@ -82,9 +82,9 @@ def on_enter(event_data):
                 broad_band_cameras = list()
                 for cam_name, cam in pocs.observatory.cameras.items():
                     if cam.filter_type.lower().startswith('ha'):
-                        narrow_band_cameras.append(cam.name)
+                        narrow_band_cameras.append(cam_name)
                     else:
-                        broad_band_cameras.append(cam.name)
+                        broad_band_cameras.append(cam_name)
 
                 if len(narrow_band_cameras) > 0:
                     pocs.say("Starting narrow band flat fields")


### PR DESCRIPTION
Small typo as described here: https://aao-org.slack.com/archives/GKB3AFZQT/p1576193221175500

Repoduced here from @AnthonyHorton:

"(cam_name  is the key of the camera in the observatory.cameras dictionary, which is what take_evening_flats() needs. cam.name is just the internal name of the camera, which these days reflects the make and model (was different in the distant past, that's how this code did work at one point)."