### PR TITLE
moved ip to camera conf

### DIFF
--- a/conf_files/huntsman.yaml
+++ b/conf_files/huntsman.yaml
@@ -58,7 +58,6 @@ pointing:
 messaging:
     cmd_port: 6500
     msg_port: 6510
-    huntsman_pro_ip: localhost #This should be updated in huntsman_local.yaml
 state_machine: /var/huntsman/huntsman-pocs/resources/state_table/huntsman.yaml
 
 ########################### Flat Fields ########################################

--- a/conf_files/pyro_camera.yaml
+++ b/conf_files/pyro_camera.yaml
@@ -31,6 +31,8 @@ directories:
     base: /var/panoptes
     images: temp
     data: data
+messaging:
+    huntsman_pro_ip: localhost #This should be updated in pyro_camera_local.yaml
 #
 # SBIG camera with Birger focuser:
 # name: camera.sbig.001

--- a/huntsman/utils/sshfs_mount.py
+++ b/huntsman/utils/sshfs_mount.py
@@ -107,10 +107,13 @@ def mount_sshfs(logger=None, user=None, mountpoint=None):
     if mountpoint is None:
         mountpoint = get_mountpoint()
     
+    #Retrieve the IP of the remote
+    config_camera = load_config(config_files=['pyro_camera.yaml'])
+    remote_ip = config_camera['messaging']['huntsman_pro_ip']
+    
     #Specify the remote directory
-    config = load_config()
-    remote_ip = config['messaging']['huntsman_pro_ip']
-    remote_dir= config['directories']['base']
+    config_huntsman = load_config()    
+    remote_dir = config_huntsman['directories']['base']
     remote = f"{user}@{remote_ip}:{remote_dir}"
     
     #Check if the remote is already mounted, if so, unmount
@@ -123,7 +126,7 @@ def mount_sshfs(logger=None, user=None, mountpoint=None):
     
     #Symlink the directories
     original = os.path.join(mountpoint, 'images')
-    link = config['directories']['images']
+    link = config_huntsman['directories']['images']
     
     #If link already exists, make sure it is pointing to the right place
     if os.path.exists(link):


### PR DESCRIPTION
Removes the need for a huntsman_local.yaml. huntsman_pro_ip is now defined in pyro_camera_local.yaml, which needs to be updated on the pis.