### PR TITLE
minor tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ cache:
 env:
   - PANDIR=/var/huntsman POCS=${PANDIR}/POCS PANUSER=$USER HUNTSMAN_POCS=${PANDIR}/huntsman-pocs
 before_install:
+  #Update setuptools
+  - pip install setuptools --upgrade 
   # Set up directories.
   - sudo mkdir $PANDIR && sudo chmod 777 $PANDIR
   - mkdir -p $PANDIR/logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,13 @@ cache:
 env:
   - PANDIR=/var/huntsman POCS=${PANDIR}/POCS PANUSER=$USER HUNTSMAN_POCS=${PANDIR}/huntsman-pocs
 before_install:
-  #Update setuptools
-  - pip install setuptools --upgrade 
   # Set up directories.
   - sudo mkdir $PANDIR && sudo chmod 777 $PANDIR
   - mkdir -p $PANDIR/logs
   - ln -s $TRAVIS_BUILD_DIR $PANDIR/huntsman-pocs
   # Install testing dependencies.
   - pip install -U pip
+  - pip install setuptools --upgrade 
   - pip install coveralls
   - cd $PANDIR
   # Install POCS

--- a/docker/device_startup.docker
+++ b/docker/device_startup.docker
@@ -8,6 +8,8 @@ FROM raspbian/jessie
 ENV PANUSER=huntsman
 ENV PANDIR=/var/huntsman
 RUN useradd $PANUSER && mkdir $PANDIR && chown $PANUSER $PANDIR
+RUN echo dialout plugdev netdev users input spi i2c gpio | xargs -n 1 groupadd -f
+RUN usermod -a -G dialout,plugdev,netdev,users,input,spi,i2c,gpio huntsman
 
 #Extra environment variables
 ENV DEBIAN_FRONTEND=noninteractive
@@ -33,7 +35,14 @@ RUN ln -s $CONDA_PATH/bin/conda /usr/local/bin/ && \
     ln -s $CONDA_PATH/bin/python3.6 /usr/local/bin/python && \
     ln -s $CONDA_PATH/bin/pip /usr/local/bin/
 
+#==============================================================================
+#Install python deps
+
 RUN pip install --upgrade pip
+RUN pip install setuptools --upgrade
+
+RUN conda install astropy matplotlib requests scipy
+RUN pip install pymongo netifaces pyro4 pyyaml
 
 #==============================================================================
 #Huntsman-POCS
@@ -52,16 +61,10 @@ RUN git clone https://github.com/panoptes/POCS.git
 RUN git clone https://github.com/AstroHuntsman/huntsman-pocs.git
 
 WORKDIR $POCS
-RUN python setup.py develop
+RUN python setup.py develop --no-deps
 
 WORKDIR $HUNTSMAN_POCS
 RUN python setup.py develop
-
-#==============================================================================
-#Install python deps
-
-RUN conda install astropy matplotlib requests scipy
-RUN pip install pymongo netifaces pyro4 pyyaml
 
 #==============================================================================
 #Setup permissions for $PANUSER; specify $PANUSER as default user

--- a/scripts/run_device_container.sh
+++ b/scripts/run_device_container.sh
@@ -33,9 +33,9 @@ CONTAINER_ID=$(docker create -it --network host --cap-add SYS_ADMIN \
 docker start $CONTAINER_ID
 
 #Extract some environment variables from the container
-CONTAINER_USER=$(docker exec container bash -c 'echo "$USER"')
-CONTAINER_HOME=$(docker exec container bash -c 'echo "$HOME"')
-CONTAINER_PANDIR=$(docker exec container bash -c 'echo "$PANDIR"')
+CONTAINER_USER=$(docker exec $CONTAINER_ID bash -c 'echo "$PANUSER"')
+CONTAINER_HOME=$(docker exec $CONTAINER_ID bash -c 'echo "$HOME"')
+CONTAINER_PANDIR=$(docker exec $CONTAINER_ID bash -c 'echo "$PANDIR"')
 
 #Copy the ssh credentials from the host to the container
 docker cp ~/.ssh $CONTAINER_ID:$CONTAINER_HOME/.ssh


### PR DESCRIPTION
Minor tweaks to allow automated device startup & docker image build to work. 

POCS' dependency `readline` was not installable in the raspbian environment, which caused the docker build to fail. `readline` is a standard python module and does not need to be installed for our purposes.

- POCS dependencies are ignored, allowing docker image build to work. Actual dependencies are installed elsewhere.

- Fixed some annoying typos in the docker file.