### PR TITLE
Add libusb

### DIFF
--- a/docker/device_startup.docker
+++ b/docker/device_startup.docker
@@ -68,6 +68,7 @@ RUN export BUILD_DIR=$(pwd)/ASIBuild && \
     mkdir $BUILD_DIR && \
 
     #ZWO camera
+    apt-get -y install libusb-1.0-0-dev && \
     cd $BUILD_DIR && \
     mkdir BUILD_CAM && \
     cd BUILD_CAM && \


### PR DESCRIPTION
Apparently ZWO drivers need libusb. Now included in docker image.