### PR TITLE
panoptes-utils from current github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -e git+git://github.com/AstroHuntsman/gunagala@master#egg=gunagala
 -e git+git://github.com/panoptes/POCS@develop#egg=panoptes
+-e git+git://github.com/panoptes/panoptes-utils@develop#egg=panoptes-utils
 -e git+git://github.com/astropy/astroplan@master#egg=astroplan
 astropy >= 3.2.3
 astroquery
@@ -30,4 +31,3 @@ scikit_image >= 0.12.3
 scipy >= 0.17.1
 transitions >= 0.4.0
 wcsaxes
-panoptes-utils


### PR DESCRIPTION
Until we can do a new release of `panoptes-utils` we need to module from develop.