### PR TITLE
Add Pyro serialisers for POCS exceptions

### DIFF
--- a/huntsman/camera/__init__.py
+++ b/huntsman/camera/__init__.py
@@ -2,17 +2,12 @@ from collections import OrderedDict
 
 import Pyro4
 
-from pocs.utils import error
-
-from huntsman.utils import load_config
-
 from pocs.camera import create_cameras_from_config as create_local_cameras
-from pocs.camera.camera import AbstractCamera  # pragma: no flakes
-from pocs.camera.camera import AbstractGPhotoCamera  # pragma: no flakes
+from pocs.utils import error
+from pocs.utils import logger as logger_module
 
 from huntsman.camera.pyro import Camera as PyroCamera
-
-from pocs.utils import logger as logger_module
+from huntsman.utils import load_config
 
 
 def list_distributed_cameras(ns_host=None, logger=None):

--- a/huntsman/camera/pyro.py
+++ b/huntsman/camera/pyro.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import requests
 from warnings import warn
@@ -8,39 +7,21 @@ from threading import Thread
 from contextlib import suppress
 
 from astropy import units as u
-from astropy.io.misc import yaml as ayaml
 import Pyro4
 import Pyro4.util
-from Pyro4.util import SerializerBase
 
 from pocs.utils import load_module
 from pocs.utils import get_quantity_value
 from pocs.utils import error
 from pocs.camera import AbstractCamera
-from huntsman.focuser.pyro import Focuser as PyroFocuser
 
+from huntsman.focuser.pyro import Focuser as PyroFocuser
+# This import is needed to set up the custom (de)serialisers in the same scope
+# as the pyro test server proxy creation.
+from huntsman.utils import pyro as pyro_utils
 from huntsman.utils.config import load_device_config, query_config_server
 
-# Enable local display of remote tracebacks
-sys.excepthook = Pyro4.util.excepthook
-
-# Set up custom Pyro serialisers/de-serialisers for Astropy objects (Quantity, etc.)
-
-def astropy_to_dict(obj):
-    """Serializer function for Astropy objects using astropy.io.misc.yaml.dump()."""
-    return {"__class__": "astropy_yaml",
-            "yaml_dump": ayaml.dump(obj)}
-
-
-def dict_to_astropy(class_name, d):
-    """De-serialiser function for Astropy objects using astropy.io.misc.yaml.load()."""
-    return ayaml.load(d["yaml_dump"])
-
-SerializerBase.register_class_to_dict(u.Quantity, astropy_to_dict)
-SerializerBase.register_dict_to_class("astropy_yaml", dict_to_astropy)
-
 #==============================================================================
-
 
 class Camera(AbstractCamera):
     """

--- a/huntsman/tests/test_aardvark.py
+++ b/huntsman/tests/test_aardvark.py
@@ -5,6 +5,10 @@ import os
 
 import pytest
 import Pyro4
+import Pyro4.errors
+from astropy import units as u
+
+from pocs.utils import error
 
 from huntsman.utils import get_own_ip
 
@@ -33,7 +37,49 @@ def test_name_server(name_server):
 def test_locate_name_server(name_server):
     # Check that we can connect to the name server
     Pyro4.locateNS()
-    
+
+
+def test_test_server(test_server):
+    # Check that it is running
+    assert test_server.poll() is None
+
+
+def test_quantity_argument(test_proxy):
+    test_proxy.quantity_argument(550 * u.nm)
+    test_proxy.quantity_argument(1.21 * u.GW)
+
+
+def test_quantity_return(test_proxy):
+    q = test_proxy.quantity_return()
+    assert isinstance(q, u.Quantity)
+    assert q == 42 * u.km * u.ng / u.Ms
+
+
+def test_builtin_exception(test_proxy):
+    with pytest.raises(RuntimeError):
+        test_proxy.raise_runtimeerror()
+    with pytest.raises(AssertionError):
+        test_proxy.raise_assertionerror()
+
+
+def test_pocs_exception(test_proxy):
+    with pytest.raises(error.PanError):
+        test_proxy.raise_panerror()
+
+
+def test_pocs_subclass(test_proxy):
+    with pytest.raises(error.Timeout):
+        test_proxy.raise_timeout()
+    with pytest.raises(error.NotSupported):
+        test_proxy.raise_notsupported()
+    with pytest.raises(error.IllegalValue):
+        test_proxy.raise_illegalvalue()
+
+
+def test_undeserialisable(test_proxy):
+    with pytest.raises(Pyro4.errors.SerializeError):
+        test_proxy.raise_undeserialisable()
+
 
 def test_config_server(config_server):
     #Check we can get a config

--- a/huntsman/tests/test_aardvark.py
+++ b/huntsman/tests/test_aardvark.py
@@ -1,7 +1,6 @@
 # Named after an African nocturnal insectivore because for mysterious reasons these
 # tests were failing if run towards the end of the test suite.
 import logging
-import os
 
 import pytest
 import Pyro4
@@ -82,7 +81,7 @@ def test_undeserialisable(test_proxy):
 
 
 def test_config_server(config_server):
-    #Check we can get a config
+    # Check we can get a config
     assert config_server.poll() is None
 
 

--- a/huntsman/utils/pyro/__init__.py
+++ b/huntsman/utils/pyro/__init__.py
@@ -17,12 +17,12 @@ from huntsman.utils.config import load_device_config
 sys.excepthook = Pyro4.util.excepthook
 
 # Serialisers/deserialisers
-name_pattern = re.compile(r"error\.(\w+)'>$")
+error_pattern = re.compile(r"error\.(\w+)'>$")
 
 
 def panerror_to_dict(obj):
     """Serialiser function for POCS custom exceptions."""
-    name_match = name_pattern.search(str(obj.__class__))
+    name_match = error_pattern.search(str(obj.__class__))
     if name_match:
         exception_name = name_match.group(1)
     else:
@@ -39,7 +39,7 @@ def dict_to_panerror(class_name, d):
     try:
         exception_class = getattr(error, d['exception_name'])
     except AttributeError:
-        msg = f"error module has no exception class {exception_name}."
+        msg = f"error module has no exception class {d['exception_name']}."
         raise AttributeError(msg)
 
     return exception_class(*d["args"])
@@ -97,6 +97,7 @@ class TestServer(object):
         raise NewError("Pyro can't de-serialise this.")
 
 #==============================================================================
+
 
 def run_name_server(host=None, port=None, autoclean=0, logger=None):
     """
@@ -193,15 +194,15 @@ def run_camera_server(ignore_local=False, unmount_sshfs=True, logger=None,
     if logger is None:
         logger = DummyLogger()
 
-    #Mount the SSHFS images directory
+    # Mount the SSHFS images directory
     mountpoint = sshfs.mount_images_dir(logger=logger)
 
     Pyro4.config.SERVERTYPE = "multiplex"
 
-    #Load the config file
+    # Load the config file
     config = load_device_config(logger=logger, **kwargs)
 
-    #Specify address
+    # Specify address
     host = config.get('host', None)
     if not host:
         host = get_own_ip(verbose=True)
@@ -230,7 +231,7 @@ def run_camera_server(ignore_local=False, unmount_sshfs=True, logger=None,
             name_server.remove(name=config['name'])
             logger.info('Unregistered from name server')
 
-            #Unmount the SSHFS
+            # Unmount the SSHFS
             if unmount_sshfs:
                 sshfs.unmount(mountpoint, logger=logger)
 

--- a/huntsman/utils/pyro/__init__.py
+++ b/huntsman/utils/pyro/__init__.py
@@ -1,9 +1,100 @@
+import re
+import sys
+
 import Pyro4
 from Pyro4 import naming, errors
+from Pyro4.util import SerializerBase
+from astropy import units as u
+from astropy.io.misc import yaml as ayaml
+
+from pocs.utils import error
 
 from huntsman.camera.pyro import CameraServer
 from huntsman.utils import get_own_ip, sshfs, DummyLogger
 from huntsman.utils.config import load_device_config
+
+# Enable local display of remote tracebacks
+sys.excepthook = Pyro4.util.excepthook
+
+# Serialisers/deserialisers
+name_pattern = re.compile(r"error\.(\w+)'>$")
+
+
+def panerror_to_dict(obj):
+    """Serialiser function for POCS custom exceptions."""
+    name_match = name_pattern.search(str(obj.__class__))
+    if name_match:
+        exception_name = name_match.group(1)
+    else:
+        msg = f"Unexpected obj type: {obj}, {obj.__class__}"
+        raise ValueError(msg)
+
+    return {"__class__": "PanError",
+            "exception_name": exception_name,
+            "args": obj.args}
+
+
+def dict_to_panerror(class_name, d):
+    """Deserialiser function for POCS custom exceptions."""
+    try:
+        exception_class = getattr(error, d['exception_name'])
+    except AttributeError:
+        msg = f"error module has no exception class {exception_name}."
+        raise AttributeError(msg)
+
+    return exception_class(*d["args"])
+
+
+def astropy_to_dict(obj):
+    """Serializer function for Astropy objects using astropy.io.misc.yaml.dump()."""
+    return {"__class__": "astropy_yaml",
+            "yaml_dump": ayaml.dump(obj)}
+
+
+def dict_to_astropy(class_name, d):
+    """De-serialiser function for Astropy objects using astropy.io.misc.yaml.load()."""
+    return ayaml.load(d["yaml_dump"])
+
+
+SerializerBase.register_class_to_dict(u.Quantity, astropy_to_dict)
+SerializerBase.register_dict_to_class("astropy_yaml", dict_to_astropy)
+
+SerializerBase.register_class_to_dict(error.PanError, panerror_to_dict)
+SerializerBase.register_dict_to_class("PanError", dict_to_panerror)
+
+
+class NewError(Exception):
+    pass
+
+@Pyro4.expose
+class TestServer(object):
+
+    def quantity_argument(self, q):
+        assert isinstance(q, u.Quantity)
+
+    def quantity_return(self):
+        return 42 * u.km * u.ng / u.Ms
+
+    def raise_runtimeerror(self):
+        raise RuntimeError("This is a test RuntimeError.")
+
+    def raise_assertionerror(self):
+        assert False
+
+    def raise_panerror(self):
+        raise error.PanError("This is a test PanError.")
+
+    def raise_timeout(self):
+        raise error.Timeout("This is a test Timeout.")
+
+    def raise_notsupported(self):
+        raise error.NotSupported("This is a test NotSupported.")
+
+    def raise_illegalvalue(self):
+        raise error.IllegalValue("This is a test IllegalValue.")
+
+    def raise_undeserialisable(self):
+        raise NewError("Pyro can't de-serialise this.")
 
 #==============================================================================
 
@@ -46,6 +137,38 @@ def run_name_server(host=None, port=None, autoclean=0, logger=None):
         naming.startNSloop(host=host, port=port)
     else:
         logger.info("Pyro name server {} already running! Exiting...".format(name_server))
+
+#==============================================================================
+
+def run_test_server(logger=None):
+    """
+    Runs a Pyro test server.
+    """
+    if logger is None:
+        logger = DummyLogger()
+
+    host = get_own_ip(verbose=True)
+
+    with Pyro4.Daemon(host=host) as daemon:
+        try:
+            name_server = Pyro4.locateNS()
+        except errors.NamingError as err:
+            logger.error('Failed to locate Pyro name server: {}'.format(err))
+            exit(1)
+
+        logger.info('Found Pyro name server.')
+        uri = daemon.register(TestServer)
+        logger.info('Test server registered with daemon as {}'.format(uri))
+        name_server.register('test_server', uri, metadata={"POCS", "Test"})
+        logger.info('Registered with name server as test_server')
+        logger.info('Starting request loop... (Control-C/Command-C to exit)')
+
+        try:
+            daemon.requestLoop()
+        finally:
+            logger.info('\nShutting down...')
+            name_server.remove(name='test_server')
+            logger.info('Unregistered from name server')
 
 #==============================================================================
 
@@ -112,6 +235,3 @@ def run_camera_server(ignore_local=False, unmount_sshfs=True, logger=None,
                 sshfs.unmount(mountpoint, logger=logger)
 
 #==============================================================================
-
-
-

--- a/scripts/pyro_test_server.py
+++ b/scripts/pyro_test_server.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""
+Script to run a Pyro test server.
+"""
+from huntsman.utils.pyro import run_test_server
+
+#==============================================================================
+
+if __name__ == "__main__":
+    #Run the test server
+    run_test_server()


### PR DESCRIPTION
The aim of this PR is to enable Pyro to (de)serialise POCS exceptions (e.g. `pocs.utils.error.PanError`, `Timeout`, `NotFound`, `NotSupported`, etc.) so that if a remote camera raises one of these exceptions it will get re-raised on the main control computer. Currently what happens in this situation is that a `Pyro4.error.SerializeError` gets raised instead, and we only see the type of the remote exception and neither the message nor traceback. We have to then go digging in the remote camera logs to find out what actually happened.

This is a follow on from #158, which added (de)serialisers for astropy Quantities.

I have also taken the opportunity to move all the custom serialisers code to `huntsman.utils.pyro`, added a test server, and added tests of the custom serialisers using that test server. 