### PR TITLE
Exclude tests & hardware dependent code from test coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "huntsman/dome/musca.py"
+  - "huntsman/guide/bisque.py"
+  - "huntsman/tests/*"


### PR DESCRIPTION
Add a `.codecov.yml` file to exclude the tests themselves and code that cannot be run without real hardware from the test coverage calculations, as POCS does.