### PR TITLE
Re-enable test_run

### DIFF
--- a/huntsman/tests/test_huntsman.py
+++ b/huntsman/tests/test_huntsman.py
@@ -351,7 +351,7 @@ def test_run_no_targets_and_exit(pocs):
     pocs.run(exit_when_done=True, run_once=True)
     assert pocs.state == 'sleeping'
 
-@pytest.mark.skip
+
 def test_run(pocs):
     os.environ['POCSTIME'] = '2016-09-09 10:00:00'
     pocs.config['simulator'] = hardware.get_all_names()

--- a/states/huntsman/calibrating.py
+++ b/states/huntsman/calibrating.py
@@ -106,7 +106,7 @@ def on_enter(event_data):
         pocs.say("Coarse focusing all cameras before starting observing for the night")
         autofocus_events = pocs.observatory.autofocus_cameras(coarse=True)
         pocs.logger.debug("Started focus, going to wait")
-        pocs.wait_for_events(autofocus_events.values(), 600)  # Longer timeout?
+        pocs.wait_for_events(list(autofocus_events.values()), 600)  # Longer timeout?
 
     except Exception as e:
         pocs.logger.warning("Problem with coarse autofocus: {}".format(e))


### PR DESCRIPTION
Removes the skip mark on `test_run` from `huntsman/tests/test_huntsman.py` and fixes a bug in the `calibrating.py` state that was causing it to fail.