### PR TITLE
Fix docker camera server

### DIFF
--- a/docker/device_startup.docker
+++ b/docker/device_startup.docker
@@ -39,7 +39,7 @@ RUN ln -s $CONDA_PATH/bin/conda /usr/local/bin/ && \
 RUN pip install --upgrade pip && \
     pip install setuptools --upgrade && \
     conda install astropy matplotlib requests scipy && \
-    pip install netifaces pyro4 pyyaml pyserial
+    pip install netifaces pyro4 pyyaml pyserial pymongo
 
 #==============================================================================
 #Huntsman-POCS

--- a/scripts/startup_device.py
+++ b/scripts/startup_device.py
@@ -6,7 +6,7 @@ necessary processes automatically.
 
 This code is ideally run from inside the latest huntsman docker container.
 """
-from huntsman.utils.config import load_device_config
+from huntsman.utils.pyro.config import load_device_config
 
 
 def get_device_type(**kwargs):

--- a/scripts/startup_device.py
+++ b/scripts/startup_device.py
@@ -6,7 +6,7 @@ necessary processes automatically.
 
 This code is ideally run from inside the latest huntsman docker container.
 """
-from huntsman.utils.pyro.config import load_device_config
+from huntsman.utils.config import load_device_config
 
 
 def get_device_type(**kwargs):

--- a/scripts/startup_device.py
+++ b/scripts/startup_device.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     if device_type == 'camera':
 
         # Only attempt imports here to be as lightweight as possible
-        from huntsman.utils.pyro import run_camera_server
+        from huntsman.utils.pyro.camera_server import run_camera_server
         run_camera_server()
 
     # Dome server...


### PR DESCRIPTION
Fixes two import errors causing the camera server to crash. One being related to the recent move around of the `pyro` code and the other relating to a missing `POCS` dependence.

Ideally, `POCS` requirements will be installed from `requirements.txt`, however this is currently failing in the docker build because of version errors. This PR does not attempt to address this, but I will make a github issue. 