### PR TITLE
Fix calibrating state

### DIFF
--- a/states/huntsman/calibrating.py
+++ b/states/huntsman/calibrating.py
@@ -6,7 +6,7 @@ from pocs.utils import current_time
 
 def _wait_for_twilight(pocs, horizon):
     '''
-    Wait for twighlight if safe to do so.
+    Wait for twilight if safe to do so.
     '''
     delay = pocs._safe_delay
 

--- a/states/huntsman/calibrating.py
+++ b/states/huntsman/calibrating.py
@@ -71,7 +71,7 @@ def on_enter(event_data):
     # Wait for twilight
     coarse_focus_timeout = 600  # Put this in a config file
     if not _wait_for_twilight(pocs, horizon='focus'):
-        print('Exiting calibrating state because it is no longer safe.')
+        pocs.logger.info('Exiting calibrating state because it is no longer safe.')
         return
 
     try:

--- a/states/huntsman/calibrating.py
+++ b/states/huntsman/calibrating.py
@@ -46,10 +46,6 @@ def on_enter(event_data):
     pocs = event_data.model
     pocs.next_state = 'parking'
 
-    # Leave the state if not safe to take calibrations
-    if not pocs.is_safe(horizon='flat'):
-        print('Exiting calibrating state because it is no longer safe.')
-        return
 
     if pocs.observatory.take_flat_fields:
 

--- a/states/huntsman/calibrating.py
+++ b/states/huntsman/calibrating.py
@@ -4,116 +4,87 @@ from astropy import units as u
 from pocs.utils import current_time
 
 
-def wait_for_sun_alt(pocs,
-                     min_altitude=None,
-                     max_altitude=None,
-                     delay=None,
-                     message="Waiting for Sun altitude. Current: {}"):
-    """
-    Wait for the altitude of the Sun to be within given limits
+def _wait_for_twilight(pocs, horizon):
+    '''
+    Wait for twighlight if safe to do so.
+    '''
+    delay = pocs._safe_delay
 
-    Args:
-        pocs :
-        min_altitude (astropy.units.Quantity, optional):
-        max_altitude (astropy.units.Quantity, optional):
-        message (str):
-    """
-    if min_altitude is None and max_altitude is None:
-        raise ValueError("At least one of min_altitude & max_altitude must be given")
-    if min_altitude is None:
-        min_altitude = -90
-    if max_altitude is None:
-        max_altitude = 90
-    if isinstance(min_altitude, u.Quantity):
-        min_altitude = min_altitude.to(u.degree).value
-    if isinstance(max_altitude, u.Quantity):
-        max_altitude = max_altitude.to(u.degree).value
+    while pocs.is_safe(horizon='flat'):
 
-    if not delay:
-        delay = pocs._safe_delay
-
-    while pocs.is_safe():
-        sun_pos = pocs.observatory.observer.altaz(current_time(),
-                                                  target=get_sun(current_time())
-                                                  ).alt
-        if sun_pos.value > max_altitude or sun_pos.value < min_altitude:
-            # Check simulator for 'night'
-            if 'night' in pocs.config['simulator']:
-                pocs.logger.info(f'Using night simulator, pretending sun down.')
-                break
-            else:
-                pocs.say(message.format(sun_pos.value))
-                pocs.sleep(delay=delay)
+        if not pocs.is_dark(horizon=horizon):
+            pocs.say('Not dark enough for coarse focusing. Waiting...')
+            pocs.sleep(delay=delay)
         else:
-            break
+            return True
+
+    return False
+
+
+def _get_cameras(pocs):
+    '''
+    Get lists of narrow and broad band cameras.
+    '''
+    narrow_band_cameras = list()
+    broad_band_cameras = list()
+    for cam_name, cam in pocs.observatory.cameras.items():
+
+        # This is a hack. There should be a narrow property in the config...
+        if cam.filter_type.lower().startswith('ha'):
+            narrow_band_cameras.append(cam_name)
+        else:
+            broad_band_cameras.append(cam_name)
+
+    return narrow_band_cameras, broad_band_cameras
 
 
 def on_enter(event_data):
-    """Pointing State
-
-    Take 30 second exposure and plate-solve to get the pointing error
-    """
+    '''
+    Calibrating state. If safe to do so, take flats and darks. Should be
+    called once at the beginning and end of the night.
+    '''
     pocs = event_data.model
-
     pocs.next_state = 'parking'
 
+    # Leave the state if not safe to take calibrations
+    if not pocs.is_safe(horizon='flat'):
+        print('Exiting calibrating state because it is no longer safe.')
+        return
+
+    if pocs.observatory.take_flat_fields:
+
+        try:
+            # Identify filter types
+            narrow_band_cameras, broad_band_cameras = _get_cameras(pocs)
+
+            # Take calibration frames
+            pocs.say("Starting narrow band flat fields")
+            pocs.observatory.take_evening_flats(camera_list=narrow_band_cameras)
+
+            pocs.say("Staring broad band flat fields")
+            pocs.observatory.take_evening_flats(camera_list=broad_band_cameras)
+
+        except Exception as err:
+            pocs.logger.warning(f'Problem with flat fielding: {err}')
+
+    # This code needs to be moved to its own state
+    # Wait for twilight
+    coarse_focus_timeout = 600  # Put this in a config file
+    if not _wait_for_twilight(pocs, horizon='focus'):
+        print('Exiting calibrating state because it is no longer safe.')
+        return
+
     try:
-
-        if pocs.observatory.take_flat_fields:
-
-            # Wait for twilight if needed
-            while True:
-                sun_pos = pocs.observatory.observer.altaz(
-                    current_time(),
-                    target=get_sun(current_time())
-                ).alt
-
-                if sun_pos.value <= 10 and sun_pos.value >= 0:
-                    pocs.say("Sun is still not down yet, will wait to take some flats")
-                    pocs.sleep(delay=60)
-                else:
-                    break
-
-            # Take the flats
-            if sun_pos.value <= 0 and sun_pos.value >= -12:
-                pocs.say("Taking some flat fields to start the night")
-
-                narrow_band_cameras = list()
-                broad_band_cameras = list()
-                for cam_name, cam in pocs.observatory.cameras.items():
-                    if cam.filter_type.lower().startswith('ha'):
-                        narrow_band_cameras.append(cam_name)
-                    else:
-                        broad_band_cameras.append(cam_name)
-
-                if len(narrow_band_cameras) > 0:
-                    pocs.say("Starting narrow band flat fields")
-                    pocs.observatory.take_evening_flats(camera_list=narrow_band_cameras)  # H-alpha
-
-                if len(broad_band_cameras) > 0:
-                    pocs.say("Staring broad band flat fields")
-                    pocs.observatory.take_evening_flats(camera_list=broad_band_cameras)   # g and r
-
-    except Exception as e:
-        pocs.logger.warning("Problem with flat fielding: {}".format(e))
-
-    # Coarse focus all cameras to start the night.
-    # Wait for nautical twilight if needed.
-    wait_for_sun_alt(pocs=pocs,
-                     max_altitude=-12 * u.degree,
-                     message="Done with flat fields, waiting for nautical twilight for  ({:.02f})")
-    try:
-        pocs.say("Coarse focusing all cameras before starting observing for the night")
+        pocs.say("Coarse focusing all cameras before starting observing for the night.")
         autofocus_events = pocs.observatory.autofocus_cameras(coarse=True)
-        pocs.logger.debug("Started focus, going to wait")
-        pocs.wait_for_events(list(autofocus_events.values()), 600)  # Longer timeout?
+        pocs.logger.debug("Waiting for coarse focus to finish.")
+        pocs.wait_for_events(list(autofocus_events.values()), coarse_focus_timeout)
 
     except Exception as e:
         pocs.logger.warning("Problem with coarse autofocus: {}".format(e))
 
     # Wait for astronomical twilight if needed
-    wait_for_sun_alt(pocs=pocs,
-                     max_altitude=-18 * u.degree,
-                     message="Done with calibrations, waiting for astronomical twilight ({:.02f})")
+    if not _wait_for_twilight(pocs, horizon='observe'):
+        return
 
     pocs.next_state = 'scheduling'

--- a/states/huntsman/calibrating.py
+++ b/states/huntsman/calibrating.py
@@ -61,7 +61,7 @@ def on_enter(event_data):
             pocs.say("Starting narrow band flat fields")
             pocs.observatory.take_evening_flats(camera_list=narrow_band_cameras)
 
-            pocs.say("Staring broad band flat fields")
+            pocs.say("Starting broad band flat fields")
             pocs.observatory.take_evening_flats(camera_list=broad_band_cameras)
 
         except Exception as err:


### PR DESCRIPTION
This PR fixes a bug in the calibrating state where if the safety check failed after the flats were taken (therefore calling the parking state), the calibrating state would ignore this and continue to do the coarse focusing. After the focusing finishes, calibrating tries to go to the scheduling state, but is unable to do so as the machine is actually in parking/parked rather than calibrating at this stage. In future we will move the coarse autofocus code to its own state.

I also heavily modified (and shrunk) the code to make proper use of the POCS horizons, which are specified in the config file, rather than hardcoded horizons. 
