### PR TITLE
Fix Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
   # Install testing dependencies.
   - pip install -U pip
   - pip install setuptools --upgrade
+  - pip install certifi --upgrade
   - pip install coveralls
   - cd $PANDIR
   # Install POCS

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 sudo: required
 language: python
 python:
-  - "3.7"
+  - "3.8"
 cache:
   pip: true
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,14 @@ before_install:
   - pip install certifi --upgrade
   - pip install coveralls
   - cd $PANDIR
+  # Install panoptes-utils
+  - git clone https://github.com/panoptes/panoptes-utils.git
+  - cd panoptes-utils
+  - python setup.py install
   # Install POCS
+  - cd ..
   - git clone https://github.com/panoptes/POCS.git
   - cd POCS
-  - pip install -r requirements.txt
   - python setup.py install
   # Create SSH key for Pyro nameservers
   - ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -N ''
@@ -46,7 +50,7 @@ install:
     iers_auto_url_mirror = https://storage.googleapis.com/panoptes-resources/iers/ser7.dat
     " >> $HOME/.astropy/config/astropy.cfg
   # Download just the IERS index.
-  - python $POCS/pocs/utils/data.py --no-narrow-field --no-wide-field
+  - python $POCS/panoptes-utils/download-data.py --no-narrow-field --no-wide-field
   - python setup.py install
 before_script:
   - echo -e "Host 127.0.0.1\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ astroplan
 astropy >= 4.0.0
 astroquery
 ccdproc
+certifi >= 2020.06.20
 codecov
 coloredlogs >= 5.0
 coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ astroplan
 astropy >= 4.0.0
 astroquery
 ccdproc
-certifi >= 2020.06.20
 codecov
 coloredlogs >= 5.0
 coveralls


### PR DESCRIPTION
The build error is:
```
error: certifi 2019.3.9 is installed but certifi>=2020.06.20 is required by {'matplotlib'}
```
Solved by upgrading `certifi` in `.travis.yaml`. 

Also incremented python version to `3.8` to resolve conflict with `panoptes-utils`.