### PR TITLE
Fix remove camera in prepare_cameras

### DIFF
--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -441,6 +441,7 @@ class HuntsmanObservatory(Observatory):
 
         # Wait for cameras to be ready
         n_cameras = len(self.cameras)
+        cameras_to_drop = []
         self.logger.debug('Waiting for cameras to be ready.')
         for i in range(1, max_attempts+1):
 
@@ -453,7 +454,7 @@ class HuntsmanObservatory(Observatory):
 
                 # If max attempts have been reached...
                 if (i == max_attempts):
-                    msg = f'Timeout while waiting for {cam_name} to be ready.'
+                    msg = f'Max attempts reached while waiting for {cam_name} to be ready.'
 
                     # Raise PanError if we need all cameras
                     if require_all_cameras:
@@ -462,8 +463,7 @@ class HuntsmanObservatory(Observatory):
                     # Drop the camera if we don't need all cameras
                     else:
                         self.logger.error(msg)
-                        self.logger.debug(f'Removing {cam_name} from {self}.')
-                        self.remove_camera(cam_name)
+                        cameras_to_drop.append(cam_name)
 
             # Terminate loop if all cameras are ready
             self.logger.debug(f'Number of ready cameras after {i} of {max_attempts} checks:'
@@ -475,6 +475,12 @@ class HuntsmanObservatory(Observatory):
                 self.logger.debug('Not all cameras are ready yet, '
                                   f'waiting another {sleep} seconds before checking again.')
                 time.sleep(sleep)
+
+        # Remove cameras that didn't become ready in time
+        # This must be done outside of the main loop to avoid a RuntimeError
+        for cam_name in cameras_to_drop:
+            self.logger.debug(f'Removing {cam_name} from {self} for not being ready.')
+            self.remove_camera(cam_name)
 
         # Raise a `PanError` if no cameras are ready.
         if num_cameras_ready == 0:

--- a/src/huntsman/pocs/tests/test_observatory.py
+++ b/src/huntsman/pocs/tests/test_observatory.py
@@ -48,6 +48,18 @@ def pocs(config_with_simulated_stuff, observatory):
 
 # ==============================================================================
 
+def test_prepare_cameras_dropping(observatory):
+    """Test that unready camera is dropped."""
+    cameras = observatory.cameras
+    camera_names = cameras.keys()
+    assert len(camera_names) > 1, "Expeted more than one camera."
+    # Override class method
+    cameras[camera_names[0]].is_ready = False
+    # This should drop the unready camera
+    observatory.prepare_cameras()
+    assert len(observatory.cameras) == len(camera_names)-1
+
+
 def test_bad_observatory(config):
     huntsman_pocs = os.environ['HUNTSMAN_POCS']
     try:

--- a/src/huntsman/pocs/tests/test_observatory.py
+++ b/src/huntsman/pocs/tests/test_observatory.py
@@ -56,7 +56,7 @@ def test_prepare_cameras_dropping(observatory):
     # Override class method
     cameras[camera_names[0]].is_ready = False
     # This should drop the unready camera
-    observatory.prepare_cameras()
+    observatory.prepare_cameras(max_attempts=1)
     assert len(observatory.cameras) == len(camera_names)-1
 
 


### PR DESCRIPTION
Fixes a bug where `observatory.prepare_cameras` would crash if a camera was removed from `cameras` (an `OrderedDict`) while looping over its entries, causing `RuntimeError('OrderedDict mutated during iteration')`. The fix is to move it outside of the loop over `cameras` items.

Also added a test to make sure it works.