### PR TITLE
Minor fixes

### DIFF
--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -700,7 +700,7 @@ class HuntsmanObservatory(Observatory):
 
             if attempt_number == max_attempts-1:
                 self.logger.debug('Max attempts have been reached for flat-fielding '
-                                  f'in {filter_name} filter. Aborting.')
+                                  f'in {observation.filter_name} filter. Aborting.')
 
         # Return the exposure times
         return exptimes

--- a/src/huntsman/pocs/scheduler/observation.py
+++ b/src/huntsman/pocs/scheduler/observation.py
@@ -91,11 +91,16 @@ class DitheredFlatObservation(DitheredObservation):
                  *args, **kwargs):
         """
         Args:
-            position (str): Center of field, can be anything accepted by
-                `~astropy.coordinates.SkyCoord`.
+            position (str or astropy.coordinates.SkyCoord): Center of field, can be 
+                a `astropy.coordinates.SkyCoord` or any valid constructor.
         """
         # Create the observation
-        field = Field('Flat Field', position.to_string('hmsdms'))
+        
+        # Convert from SkyCoord if required.
+        with suppress(AttributeError):
+            position = position.to_string('hmsdms')
+        
+        field = Field('Flat Field', position)
         super().__init__(field=field, *args, **kwargs)
 
         # Listify the exposure time


### PR DESCRIPTION
There are a few things I have encountered during #196 .

* Typo in variable code could have triggered unhandled exception when max flat field attempts were reached.
* Fixing DitheredFlatField so the constructor accepts either a string or a `SkyCoord`.  
  * Observatory was passing a `SkyCoord` (from `altaz_to_radec`):

https://github.com/AstroHuntsman/huntsman-pocs/blob/8fa93b497d3d6f69665ecec8756dd75dc9c6b14b/src/huntsman/pocs/observatory.py#L540-L546