### PR TITLE
WIP: Improved camera error handling by adding new camera & focuser property to Pyro interface

### DIFF
--- a/src/huntsman/pocs/camera/pyro.py
+++ b/src/huntsman/pocs/camera/pyro.py
@@ -122,6 +122,22 @@ class Camera(AbstractCamera):
         '''
         return self._proxy.get("is_ready")
 
+    @property
+    def can_take_internal_darks(self):
+        """ True if the camera can take internal dark exposures.
+        This will be true of cameras that have an internal mechanical shutter and can
+        be commanded to keep that shutter closed during the exposure. For cameras that
+        either lack a mechanical shutter or lack the option to keep it closed light must
+        be kept out of the camera during dark exposures by other means, e.g. an opaque
+        blank in a filterwheel, a lens cap, etc.
+        """
+        return self._proxy.get("can_take_internal_darks")
+
+    @property
+    def exposure_error(self):
+        """ Error message from the most recent exposure or None, if there was no error."""
+        return self._proxy.get("exposure_error")
+
 # Methods
 
     def connect(self):

--- a/src/huntsman/pocs/focuser/pyro.py
+++ b/src/huntsman/pocs/focuser/pyro.py
@@ -122,6 +122,19 @@ class Focuser(AbstractFocuser):
     def autofocus_mask_dilations(self, dilations):
         self._proxy.set("autofocus_mask_dilations", dilations, "focuser")
 
+    @property
+    def autofocus_make_plots(self):
+        return self._proxy.get("autofocus_make_plots", "focuser")
+
+    @autofocus_make_plots.setter
+    def autofocus_make_plots(self, make_plots):
+        self._proxy.set("autofocus_make_plots", make_plots, "focuser")
+
+    @property
+    def autofocus_error(self):
+        """ Error message from the most recent autofocus or None, if there was no error."""
+        return self._proxy.get("autofocus_error", "focuser")
+
 ##################################################################################################
 # Methods
 ##################################################################################################


### PR DESCRIPTION
Add new camera and focuser properties to the Pyro interface so that they can be used in huntsman-pocs.

Specifically:

1. Camera `.can_take_internal_darks` property (read only). This isn't actually anything to do with error handling but it's in POCS `develop` now so should be accessible for huntsman-pocs remote cameras too.
1. Camera `.exposure_error` property (read only). This will be `None` unless the most recent exposure taken by the camera raised an exception, in which case it will be equal to the string representation of that exception. By checking this after an exposure (or observation) has completed it is possible for calling code to detect cameras errors and respond accordingly, e.g. deleting failed cameras from the camera list.
1. Focuser `.autofocus_make_plots` property (read/write), can be used to check or set whether to produce the autofocus plots. This can still be overriden by setting the `make_plots` argument of the call to `autofocus()`.
1. Focuser `.autofocus_error` property (read only). This will be `None` unless the most recent autofocus taken by the focuser raise an exception, in which case it will be equal to the string representation of that exception. By checking this after an autofocus sequence has complete it is possible for calling code to detect camera errors and respond accordingly, e.g. deleting failed cameras from the camera list. 

**Note:** Apart from `.can_take_internal_darks` these new properties do not exist in POCS `develop`, only in the https://github.com/AnthonyHorton/POCS/tree/error-handling branch. See PR https://github.com/panoptes/POCS/pull/1003 for more details.