### PR TITLE
Fixed bug in filename path of darks

### DIFF
--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -364,6 +364,8 @@ class HuntsmanObservatory(Observatory):
             with suppress(AttributeError):
                 exptime = exptime.to_value(u.second)
 
+            dark_obs = self._create_dark_observation(exptime)
+
             # Loop over exposure times for each camera.
             for num in range(n_darks):
 
@@ -375,7 +377,6 @@ class HuntsmanObservatory(Observatory):
                 for camera in cameras_list.values():
 
                     # Create dark observation
-                    dark_obs = self._create_dark_observation(exptime)
                     fits_headers = self.get_standard_headers(observation=dark_obs)
                     # Common start time for cameras
                     fits_headers['start_time'] = utils.flatten_time(start_time)
@@ -387,7 +388,7 @@ class HuntsmanObservatory(Observatory):
                                         dark_obs.seq_time)
 
                     filename = os.path.join(
-                        path, f'{imtype}_{dark_obs.current_exp_num:02d}.{camera.file_extension}')
+                        path, f'{imtype}_{num:02d}.{camera.file_extension}')
 
                     # Take picture and get event
                     camera_event = camera.take_observation(

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -327,6 +327,7 @@ class HuntsmanObservatory(Observatory):
                          sleep=10,
                          camera_names=None,
                          n_darks=10,
+                         imtype='dark',
                          *args, **kwargs
                          ):
         """Take n_darks dark frames for each exposure time specified,
@@ -337,6 +338,7 @@ class HuntsmanObservatory(Observatory):
             sleep (float, optional): Time in seconds to sleep between dark sequences.
             camera_names (list, optional): List of cameras to use for darks
             n_darks (int, optional): Number of darks to be taken per exptime
+            imtype (str, optional): type of image
         """
 
         if camera_names is None:
@@ -378,13 +380,14 @@ class HuntsmanObservatory(Observatory):
                     # Common start time for cameras
                     fits_headers['start_time'] = utils.flatten_time(start_time)
 
+                    # Create filename
+                    path = os.path.join(image_dir,
+                                        'darks',
+                                        camera.uid,
+                                        dark_obs.seq_time)
+
                     filename = os.path.join(
-                        image_dir,
-                        'darks',
-                        camera.uid,
-                        f'{exptime}',
-                        dark_obs.seq_time,
-                        f'dark_{num:02d}.{camera.file_extension}')
+                        path, f'{imtype}_{dark_obs.current_exp_num:02d}.{camera.file_extension}')
 
                     # Take picture and get event
                     camera_event = camera.take_observation(


### PR DESCRIPTION
Hi, 

This PR fixes a small bug that created a different time sequence for each dark. This has been tested locally with hardware and it's working well. The filename path of darks is now the right one.

Cheers,
Jaime.