### PR TITLE
Add feature for taking a different number of darks per exptime.

### DIFF
--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import time
+import numpy as np
 from contextlib import suppress
 from functools import partial
 from collections import defaultdict
@@ -356,8 +357,14 @@ class HuntsmanObservatory(Observatory):
         # of cameras times the number of exptimes times n_darks.
         darks_filenames = []
 
+        if not isinstance(exptimes, list):
+            exptimes = [exptimes]
+
+        if not isinstance(n_darks, list):
+            n_darks = np.ones(len(exptimes)) * n_darks
+
         # Loop over cameras.
-        for exptime in exptimes:
+        for exptime, n_darks in zip(exptimes, n_darks):
 
             start_time = utils.current_time()
 

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -327,18 +327,18 @@ class HuntsmanObservatory(Observatory):
                          exptimes,
                          sleep=10,
                          camera_names=None,
-                         n_darks=10,
+                         dark_sequence=10,
                          imtype='dark',
                          *args, **kwargs
                          ):
-        """Take n_darks dark frames for each exposure time specified,
+        """Take a dark_sequence of dark frames for each exposure time specified,
            for each camera.
 
         Args:
             exptimes (list): List of exposure times for darks
             sleep (float, optional): Time in seconds to sleep between dark sequences.
             camera_names (list, optional): List of cameras to use for darks
-            n_darks (int, optional): Number of darks to be taken per exptime
+            dark_sequence (int or list, optional): Number of darks to be taken per exptime
             imtype (str, optional): type of image
         """
 
@@ -351,20 +351,20 @@ class HuntsmanObservatory(Observatory):
 
         image_dir = self.config['directories']['images']
 
-        self.logger.debug(f"Going to take {n_darks} dark-fields for each of these exposure times {exptimes}")
+        self.logger.debug(f"Going to take {dark_sequence} dark-fields for each of these exposure times {exptimes}")
 
         # List to check that the final number of darks is equal to the number
-        # of cameras times the number of exptimes times n_darks.
+        # of cameras times the number of exptimes times dark_sequence.
         darks_filenames = []
 
         if not isinstance(exptimes, list):
             exptimes = [exptimes]
 
-        if not isinstance(n_darks, list):
-            n_darks = np.ones(len(exptimes)) * n_darks
+        if not isinstance(dark_sequence, list):
+            dark_sequence = np.ones(len(exptimes), dtype=int) * dark_sequence
 
         # Loop over cameras.
-        for exptime, n_darks in zip(exptimes, n_darks):
+        for exptime, num_darks in zip(exptimes, dark_sequence):
 
             start_time = utils.current_time()
 
@@ -374,7 +374,7 @@ class HuntsmanObservatory(Observatory):
             dark_obs = self._create_dark_observation(exptime)
 
             # Loop over exposure times for each camera.
-            for num in range(n_darks):
+            for num in range(num_darks):
 
                 self.logger.debug(f'Darks sequence #{num} of exposure time {exptime}s')
 

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -364,6 +364,8 @@ class HuntsmanObservatory(Observatory):
             with suppress(AttributeError):
                 exptime = exptime.to_value(u.second)
 
+            dark_obs = self._create_dark_observation(exptime)
+
             # Loop over exposure times for each camera.
             for num in range(n_darks):
 
@@ -375,7 +377,6 @@ class HuntsmanObservatory(Observatory):
                 for camera in cameras_list.values():
 
                     # Create dark observation
-                    dark_obs = self._create_dark_observation(exptime)
                     fits_headers = self.get_standard_headers(observation=dark_obs)
                     # Common start time for cameras
                     fits_headers['start_time'] = utils.flatten_time(start_time)
@@ -387,7 +388,7 @@ class HuntsmanObservatory(Observatory):
                                         dark_obs.seq_time)
 
                     filename = os.path.join(
-                        path, f'{imtype}_{dark_obs.current_exp_num:02d}.{camera.file_extension}')
+                        path, f'{imtype}_{num:02d}.{camera.file_extension}')
 
                     # Take picture and get event
                     camera_event = camera.take_observation(

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -327,18 +327,18 @@ class HuntsmanObservatory(Observatory):
                          exptimes,
                          sleep=10,
                          camera_names=None,
-                         dark_sequence=10,
+                         n_darks=10,
                          imtype='dark',
                          *args, **kwargs
                          ):
-        """Take a dark_sequence of dark frames for each exposure time specified,
+        """Take a n_darks of dark frames for each exposure time specified,
            for each camera.
 
         Args:
             exptimes (list): List of exposure times for darks
             sleep (float, optional): Time in seconds to sleep between dark sequences.
             camera_names (list, optional): List of cameras to use for darks
-            dark_sequence (int or list, optional): Number of darks to be taken per exptime
+            n_darks (int or list, optional): Number of darks to be taken per exptime
             imtype (str, optional): type of image
         """
 
@@ -351,20 +351,20 @@ class HuntsmanObservatory(Observatory):
 
         image_dir = self.config['directories']['images']
 
-        self.logger.debug(f"Going to take {dark_sequence} dark-fields for each of these exposure times {exptimes}")
+        self.logger.debug(f"Going to take {n_darks} dark-fields for each of these exposure times {exptimes}")
 
         # List to check that the final number of darks is equal to the number
-        # of cameras times the number of exptimes times dark_sequence.
+        # of cameras times the number of exptimes times n_darks.
         darks_filenames = []
 
         if not isinstance(exptimes, list):
             exptimes = [exptimes]
 
-        if not isinstance(dark_sequence, list):
-            dark_sequence = np.ones(len(exptimes), dtype=int) * dark_sequence
+        if not isinstance(n_darks, list):
+            n_darks = np.ones(len(exptimes), dtype=int) * n_darks
 
         # Loop over cameras.
-        for exptime, num_darks in zip(exptimes, dark_sequence):
+        for exptime, num_darks in zip(exptimes, n_darks):
 
             start_time = utils.current_time()
 

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -327,6 +327,7 @@ class HuntsmanObservatory(Observatory):
                          sleep=10,
                          camera_names=None,
                          n_darks=10,
+                         imtype='dark',
                          *args, **kwargs
                          ):
         """Take n_darks dark frames for each exposure time specified,
@@ -337,6 +338,7 @@ class HuntsmanObservatory(Observatory):
             sleep (float, optional): Time in seconds to sleep between dark sequences.
             camera_names (list, optional): List of cameras to use for darks
             n_darks (int, optional): Number of darks to be taken per exptime
+            imtype (str, optional): type of image
         """
 
         if camera_names is None:
@@ -378,13 +380,14 @@ class HuntsmanObservatory(Observatory):
                     # Common start time for cameras
                     fits_headers['start_time'] = utils.flatten_time(start_time)
 
+                    # Create filename
+                    path = os.path.join(image_dir,
+                                        'darks',
+                                        camera.uid,
+                                        dark_obs.seq_time)
+
                     filename = os.path.join(
-                        image_dir,
-                        'darks',
-                        camera.uid,
-                        f'{exptime}',
-                        dark_obs.seq_time,
-                        f'dark_{num:02d}.{camera.file_extension}')
+                        path, f'{imtype}_{dark_obs.current_exp_num:02d}.{camera.file_extension}')
 
                     # Take picture and get event
                     camera_event = camera.take_observation(

--- a/src/huntsman/pocs/tests/test_huntsman.py
+++ b/src/huntsman/pocs/tests/test_huntsman.py
@@ -261,11 +261,11 @@ def test_darks_collection_simulator(pocs, tmpdir):
 
     if len(exptimes_list) > 0:
         pocs.logger.info("I'm starting with dark-field exposures")
-        ndarks_per_exp = 2
+        n_darks = 2
         darks = pocs.observatory.take_dark_fields(exptimes_list,
-                                                  dark_sequence=ndarks_per_exp)
+                                                  n_darks=n_darks)
         expected_number_of_darks = (len(pocs.observatory.cameras.keys())
-                                    * ndarks_per_exp * len(exptimes_list))
+                                    * n_darks * len(exptimes_list))
 
         for filename in darks:
             assert(os.path.basename(filename).endswith('fits') is True)

--- a/src/huntsman/pocs/tests/test_huntsman.py
+++ b/src/huntsman/pocs/tests/test_huntsman.py
@@ -263,7 +263,7 @@ def test_darks_collection_simulator(pocs, tmpdir):
         pocs.logger.info("I'm starting with dark-field exposures")
         ndarks_per_exp = 2
         darks = pocs.observatory.take_dark_fields(exptimes_list,
-                                                  n_darks=ndarks_per_exp)
+                                                  dark_sequence=ndarks_per_exp)
         expected_number_of_darks = (len(pocs.observatory.cameras.keys())
                                     * ndarks_per_exp * len(exptimes_list))
 


### PR DESCRIPTION
Hi, 

This PR includes some modifications that allow `take_dark_fields` to take a different number of darks per exptime. This may come in handy when we want a variable number of darks, i.e. for small exptimes we would ideally want more darks, but for larger exptimes we would want to limit to a small number of darks.

Please review and let me know if everything's ok.

PS. This was tested on the control computer and it works perfectly.

Cheers,
Jaime.