### PR TITLE
Integrate changes to take_dark_fields() method and DarkObservation class

### DIFF
--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import time
+import numpy as np
 from contextlib import suppress
 from functools import partial
 from collections import defaultdict
@@ -356,8 +357,14 @@ class HuntsmanObservatory(Observatory):
         # of cameras times the number of exptimes times n_darks.
         darks_filenames = []
 
+        if not isinstance(exptimes, list):
+            exptimes = [exptimes]
+
+        if not isinstance(n_darks, list):
+            n_darks = np.ones(len(exptimes)) * n_darks
+
         # Loop over cameras.
-        for exptime in exptimes:
+        for exptime, n_darks in zip(exptimes, n_darks):
 
             start_time = utils.current_time()
 

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -327,18 +327,18 @@ class HuntsmanObservatory(Observatory):
                          exptimes,
                          sleep=10,
                          camera_names=None,
-                         n_darks=10,
+                         dark_sequence=10,
                          imtype='dark',
                          *args, **kwargs
                          ):
-        """Take n_darks dark frames for each exposure time specified,
+        """Take a dark_sequence of dark frames for each exposure time specified,
            for each camera.
 
         Args:
             exptimes (list): List of exposure times for darks
             sleep (float, optional): Time in seconds to sleep between dark sequences.
             camera_names (list, optional): List of cameras to use for darks
-            n_darks (int, optional): Number of darks to be taken per exptime
+            dark_sequence (int or list, optional): Number of darks to be taken per exptime
             imtype (str, optional): type of image
         """
 
@@ -351,20 +351,20 @@ class HuntsmanObservatory(Observatory):
 
         image_dir = self.config['directories']['images']
 
-        self.logger.debug(f"Going to take {n_darks} dark-fields for each of these exposure times {exptimes}")
+        self.logger.debug(f"Going to take {dark_sequence} dark-fields for each of these exposure times {exptimes}")
 
         # List to check that the final number of darks is equal to the number
-        # of cameras times the number of exptimes times n_darks.
+        # of cameras times the number of exptimes times dark_sequence.
         darks_filenames = []
 
         if not isinstance(exptimes, list):
             exptimes = [exptimes]
 
-        if not isinstance(n_darks, list):
-            n_darks = np.ones(len(exptimes)) * n_darks
+        if not isinstance(dark_sequence, list):
+            dark_sequence = np.ones(len(exptimes), dtype=int) * dark_sequence
 
         # Loop over cameras.
-        for exptime, n_darks in zip(exptimes, n_darks):
+        for exptime, num_darks in zip(exptimes, dark_sequence):
 
             start_time = utils.current_time()
 
@@ -374,7 +374,7 @@ class HuntsmanObservatory(Observatory):
             dark_obs = self._create_dark_observation(exptime)
 
             # Loop over exposure times for each camera.
-            for num in range(n_darks):
+            for num in range(num_darks):
 
                 self.logger.debug(f'Darks sequence #{num} of exposure time {exptime}s')
 

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import time
-import numpy as np
 from contextlib import suppress
 from functools import partial
 from collections import defaultdict
@@ -331,14 +330,18 @@ class HuntsmanObservatory(Observatory):
                          imtype='dark',
                          *args, **kwargs
                          ):
-        """Take a n_darks of dark frames for each exposure time specified,
+        """Take n_darks for each exposure time specified,
            for each camera.
 
         Args:
             exptimes (list): List of exposure times for darks
             sleep (float, optional): Time in seconds to sleep between dark sequences.
             camera_names (list, optional): List of cameras to use for darks
-            n_darks (int or list, optional): Number of darks to be taken per exptime
+            n_darks (int or list, optional): if int, the same number of darks will be taken
+                for each exptime. If list, the len has to be the same than len(exptimes), where each
+                element is the number of darks we want for the corresponding exptime, e.g.:
+                take_dark_fields(exptimes=[1*u.s, 60*u.s, 15*u.s], n_darks=[30, 10, 20])
+                will take 30x1s, 10x60s, and 20x15s darks
             imtype (str, optional): type of image
         """
 
@@ -361,7 +364,7 @@ class HuntsmanObservatory(Observatory):
             exptimes = [exptimes]
 
         if not isinstance(n_darks, list):
-            n_darks = np.ones(len(exptimes), dtype=int) * n_darks
+            n_darks = [n_darks] * len(exptimes)
 
         # Loop over cameras.
         for exptime, num_darks in zip(exptimes, n_darks):

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -13,6 +13,7 @@ from pocs.observatory import Observatory
 from pocs.scheduler import constraint
 from pocs.scheduler.observation import Field
 from pocs.utils import error
+from pocs.utils import listify
 from pocs import utils
 
 from panoptes.utils.time import wait_for_events
@@ -360,11 +361,10 @@ class HuntsmanObservatory(Observatory):
         # of cameras times the number of exptimes times n_darks.
         darks_filenames = []
 
-        if not isinstance(exptimes, list):
-            exptimes = [exptimes]
+        exptimes = listify(exptimes)
 
         if not isinstance(n_darks, list):
-            n_darks = [n_darks] * len(exptimes)
+            n_darks = listify(n_darks) * len(exptimes)
 
         # Loop over cameras.
         for exptime, num_darks in zip(exptimes, n_darks):

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -364,6 +364,8 @@ class HuntsmanObservatory(Observatory):
             with suppress(AttributeError):
                 exptime = exptime.to_value(u.second)
 
+            dark_obs = self._create_dark_observation(exptime)
+
             # Loop over exposure times for each camera.
             for num in range(n_darks):
 
@@ -375,7 +377,6 @@ class HuntsmanObservatory(Observatory):
                 for camera in cameras_list.values():
 
                     # Create dark observation
-                    dark_obs = self._create_dark_observation(exptime)
                     fits_headers = self.get_standard_headers(observation=dark_obs)
                     # Common start time for cameras
                     fits_headers['start_time'] = utils.flatten_time(start_time)
@@ -387,7 +388,7 @@ class HuntsmanObservatory(Observatory):
                                         dark_obs.seq_time)
 
                     filename = os.path.join(
-                        path, f'{imtype}_{dark_obs.current_exp_num:02d}.{camera.file_extension}')
+                        path, f'{imtype}_{num:02d}.{camera.file_extension}')
 
                     # Take picture and get event
                     camera_event = camera.take_observation(

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -345,18 +345,19 @@ class HuntsmanObservatory(Observatory):
         self.logger.info('Finished flat-fielding.')
 
     def take_dark_fields(self,
-                         exptimes,
+                         exptimes=[],
                          sleep=10,
                          camera_names=None,
                          n_darks=10,
                          imtype='dark',
+                         set_from_config=False,
                          *args, **kwargs
                          ):
         """Take n_darks for each exposure time specified,
            for each camera.
 
         Args:
-            exptimes (list): List of exposure times for darks
+            exptimes (list, optional): List of exposure times for darks
             sleep (float, optional): Time in seconds to sleep between dark sequences.
             camera_names (list, optional): List of cameras to use for darks
             n_darks (int or list, optional): if int, the same number of darks will be taken
@@ -364,6 +365,7 @@ class HuntsmanObservatory(Observatory):
                 element is the number of darks we want for the corresponding exptime, e.g.:
                 take_dark_fields(exptimes=[1*u.s, 60*u.s, 15*u.s], n_darks=[30, 10, 20])
                 will take 30x1s, 10x60s, and 20x15s darks
+            set_from_config (bool, optional): flag to set exptimes and n_darks directly from config file.
             imtype (str, optional): type of image
         """
 
@@ -374,9 +376,17 @@ class HuntsmanObservatory(Observatory):
 
         self.logger.debug(f'Using cameras {cameras_list}')
 
-        image_dir = self.config['directories']['images']
+        filterwheel_events = dict()
 
-        self.logger.debug(f"Going to take {n_darks} dark-fields for each of these exposure times {exptimes}")
+        self.logger.debug(f'Moving all camera filterwheels to blank filter')
+
+        # Move all the camera filterwheels to the blank position.
+        for camera in cameras_list.values():
+            if camera.filterwheel.current_filter != "blank":
+                filterwheel_event = camera.filterwheel.move_to("blank")
+                filterwheel_events[camera] = filterwheel_event
+        self.logger.debug('Waiting for all the filterwheels to be on blank filter...')
+        wait_for_events(list(filterwheel_events.values()))
 
         # List to check that the final number of darks is equal to the number
         # of cameras times the number of exptimes times n_darks.
@@ -387,6 +397,12 @@ class HuntsmanObservatory(Observatory):
         if not isinstance(n_darks, list):
             n_darks = listify(n_darks) * len(exptimes)
 
+        if set_from_config:
+            exptimes = self.config["calibration"]["darks"]["exposure_time"]
+            n_darks = self.config["calibration"]["darks"]["n_darks"]
+
+        self.logger.debug(f"Going to take {n_darks} dark-fields for each of these exposure times {exptimes}")
+
         # Loop over cameras.
         for exptime, num_darks in zip(exptimes, n_darks):
 
@@ -395,6 +411,7 @@ class HuntsmanObservatory(Observatory):
             with suppress(AttributeError):
                 exptime = exptime.to_value(u.second)
 
+            # Create dark observation
             dark_obs = self._create_dark_observation(exptime)
 
             # Loop over exposure times for each camera.
@@ -407,14 +424,13 @@ class HuntsmanObservatory(Observatory):
                 # Take a given number of exposures for each exposure time.
                 for camera in cameras_list.values():
 
-                    # Create dark observation
+                    # Set header
                     fits_headers = self.get_standard_headers(observation=dark_obs)
                     # Common start time for cameras
                     fits_headers['start_time'] = utils.flatten_time(start_time)
 
                     # Create filename
-                    path = os.path.join(image_dir,
-                                        'darks',
+                    path = os.path.join(dark_obs.directory,
                                         camera.uid,
                                         dark_obs.seq_time)
 

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -327,18 +327,18 @@ class HuntsmanObservatory(Observatory):
                          exptimes,
                          sleep=10,
                          camera_names=None,
-                         dark_sequence=10,
+                         n_darks=10,
                          imtype='dark',
                          *args, **kwargs
                          ):
-        """Take a dark_sequence of dark frames for each exposure time specified,
+        """Take a n_darks of dark frames for each exposure time specified,
            for each camera.
 
         Args:
             exptimes (list): List of exposure times for darks
             sleep (float, optional): Time in seconds to sleep between dark sequences.
             camera_names (list, optional): List of cameras to use for darks
-            dark_sequence (int or list, optional): Number of darks to be taken per exptime
+            n_darks (int or list, optional): Number of darks to be taken per exptime
             imtype (str, optional): type of image
         """
 
@@ -351,20 +351,20 @@ class HuntsmanObservatory(Observatory):
 
         image_dir = self.config['directories']['images']
 
-        self.logger.debug(f"Going to take {dark_sequence} dark-fields for each of these exposure times {exptimes}")
+        self.logger.debug(f"Going to take {n_darks} dark-fields for each of these exposure times {exptimes}")
 
         # List to check that the final number of darks is equal to the number
-        # of cameras times the number of exptimes times dark_sequence.
+        # of cameras times the number of exptimes times n_darks.
         darks_filenames = []
 
         if not isinstance(exptimes, list):
             exptimes = [exptimes]
 
-        if not isinstance(dark_sequence, list):
-            dark_sequence = np.ones(len(exptimes), dtype=int) * dark_sequence
+        if not isinstance(n_darks, list):
+            n_darks = np.ones(len(exptimes), dtype=int) * n_darks
 
         # Loop over cameras.
-        for exptime, num_darks in zip(exptimes, dark_sequence):
+        for exptime, num_darks in zip(exptimes, n_darks):
 
             start_time = utils.current_time()
 

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -327,6 +327,7 @@ class HuntsmanObservatory(Observatory):
                          sleep=10,
                          camera_names=None,
                          n_darks=10,
+                         imtype='dark',
                          *args, **kwargs
                          ):
         """Take n_darks dark frames for each exposure time specified,
@@ -337,6 +338,7 @@ class HuntsmanObservatory(Observatory):
             sleep (float, optional): Time in seconds to sleep between dark sequences.
             camera_names (list, optional): List of cameras to use for darks
             n_darks (int, optional): Number of darks to be taken per exptime
+            imtype (str, optional): type of image
         """
 
         if camera_names is None:
@@ -378,13 +380,14 @@ class HuntsmanObservatory(Observatory):
                     # Common start time for cameras
                     fits_headers['start_time'] = utils.flatten_time(start_time)
 
+                    # Create filename
+                    path = os.path.join(image_dir,
+                                        'darks',
+                                        camera.uid,
+                                        dark_obs.seq_time)
+
                     filename = os.path.join(
-                        image_dir,
-                        'darks',
-                        camera.uid,
-                        f'{exptime}',
-                        dark_obs.seq_time,
-                        f'dark_{num:02d}.{camera.file_extension}')
+                        path, f'{imtype}_{dark_obs.current_exp_num:02d}.{camera.file_extension}')
 
                     # Take picture and get event
                     camera_event = camera.take_observation(

--- a/src/huntsman/pocs/scheduler/dark_observation.py
+++ b/src/huntsman/pocs/scheduler/dark_observation.py
@@ -1,3 +1,4 @@
+import os
 from astropy import units as u
 from contextlib import suppress
 
@@ -36,6 +37,9 @@ class DarkObservation(Observation):
         self._field = listify(self.field)
 
         self.extra_config = kwargs
+
+        # Specify directory root for file storage
+        self._directory = os.path.join(self._image_dir, 'darks')
 
     @property
     def exptime(self):

--- a/src/huntsman/pocs/tests/test_huntsman.py
+++ b/src/huntsman/pocs/tests/test_huntsman.py
@@ -261,11 +261,11 @@ def test_darks_collection_simulator(pocs, tmpdir):
 
     if len(exptimes_list) > 0:
         pocs.logger.info("I'm starting with dark-field exposures")
-        ndarks_per_exp = 2
+        n_darks = 2
         darks = pocs.observatory.take_dark_fields(exptimes_list,
-                                                  dark_sequence=ndarks_per_exp)
+                                                  n_darks=n_darks)
         expected_number_of_darks = (len(pocs.observatory.cameras.keys())
-                                    * ndarks_per_exp * len(exptimes_list))
+                                    * n_darks * len(exptimes_list))
 
         for filename in darks:
             assert(os.path.basename(filename).endswith('fits') is True)

--- a/src/huntsman/pocs/tests/test_huntsman.py
+++ b/src/huntsman/pocs/tests/test_huntsman.py
@@ -263,7 +263,7 @@ def test_darks_collection_simulator(pocs, tmpdir):
         pocs.logger.info("I'm starting with dark-field exposures")
         ndarks_per_exp = 2
         darks = pocs.observatory.take_dark_fields(exptimes_list,
-                                                  n_darks=ndarks_per_exp)
+                                                  dark_sequence=ndarks_per_exp)
         expected_number_of_darks = (len(pocs.observatory.cameras.keys())
                                     * ndarks_per_exp * len(exptimes_list))
 


### PR DESCRIPTION
Hi all,

This PR integrates all of the changes I did on the control computer (along with some small fixes) when working with Huntsman in the DFW week. This is currently working on the control computer and I tested all the changes using the actual telescope before doing this PR. 

The one major change I did is basically to make sure that filterwheels are located in the `blank` filter before starting to take exposures, something that was missed before and that had to be handled externally. Everything is now done by the method itself. I added a minor change for grabbing `exptimes` and `n_darks` from config file by using `set_from_config=True` (default `False`). Otherwise, all the changes are just very small things and typos.

Please let me know any comment or suggestion. 

Cheers,
Jaime A.
