### PR TITLE
Fix pyro FW move_to

### DIFF
--- a/src/huntsman/pocs/camera/pyro/service.py
+++ b/src/huntsman/pocs/camera/pyro/service.py
@@ -107,8 +107,8 @@ class CameraService(object):
     def has_filterwheel(self):
         return self._camera.filterwheel is not None
 
-    def filterwheel_move_to(self, position):
-        self._camera.filterwheel.move_to(position)
+    def filterwheel_move_to(self, new_position, **kwargs):
+        self._camera.filterwheel.move_to(new_position, **kwargs)
 
     # Event access
 

--- a/src/huntsman/pocs/filterwheel/pyro.py
+++ b/src/huntsman/pocs/filterwheel/pyro.py
@@ -72,9 +72,12 @@ class FilterWheel(AbstractFilterWheel):
 
         self.logger.debug(f"{self} connected.")
 
+    def move_to(self, new_position, **kwargs):
+        self._proxy.filterwheel_move_to(new_position=new_position, **kwargs)
+
     ################################################################################################
-    # Private methods
+    # Private Methods
     ################################################################################################
 
-    def _move_to(self, position):
-        self._proxy.filterwheel_move_to(position)
+    def _move_to(self, *args, **kwargs):
+        raise NotImplementedError


### PR DESCRIPTION
Small PR to fix a small but significant bug in the pyro FW code that caused problems with the `move_to` method during hardware tests.