### PR TITLE
Flat field config and next exptime calculation

### DIFF
--- a/conf_files/huntsman.yaml
+++ b/conf_files/huntsman.yaml
@@ -16,7 +16,7 @@ location:
     - [[45, 355], [45, 5]]  # telstra tower rough coordinates
   timezone: Australia/Sydney
   twilight_horizon: 0  # Degrees
-  
+
 db:
   name: huntsman
   type: file
@@ -65,9 +65,10 @@ flat_fields:
     - deux
     - drei
     - quattro
-  max_num_exposures: 5
-  max_attempts: 10
-  max_exptime: 120
+  required_exposures: 5  # Per filter per camera
+  max_attempts: 10  # Per filter per camera
+  max_exptime: 60
+  min_exptime: 0.0001
 
 pointing:
     exptime: 30

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -691,7 +691,7 @@ class HuntsmanObservatory(Observatory):
             exptime = exptime / sky_factor
         else:
             exptime = exptime * sky_factor
-        return round(exptime.to_value(u.second)) * u.second
+        return exptime.to_value(u.second) * u.second
 
     def _take_flat_observation(self, exptimes, observation, fits_headers=None, dark=False,
                                timeout=120, **kwargs):

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -196,7 +196,7 @@ class HuntsmanObservatory(Observatory):
                 Default 0.17.
             tolerance (float, optional): The minimum precision on the average counts required to
                 keep the exposure, expressed as a fraction of the dynamic range. Default 0.1.
-            max_num_exposures (int, optional): Maximum number of good flat-fields to
+            required_exposures (int, optional): Maximum number of good flat-fields to
                 take per filter. Default 10.
             max_attempts (int, optional): Number of attempts per camera-filter pair to get good
                 flat-field exposures before aborting. Default 20.
@@ -517,7 +517,7 @@ class HuntsmanObservatory(Observatory):
 
     def _take_autoflats(self, cameras, observation, safety_func, tolerance=0.05,
                         target_scaling=0.17, bias=32, min_exptime=1 * u.second,
-                        max_exptime=60 * u.second, max_num_exposures=10, max_attempts=20,
+                        max_exptime=60 * u.second, required_exposures=10, max_attempts=20,
                         *args, **kwargs):
         """Take flat fields iteratively by automatically estimating exposure times.
 
@@ -601,10 +601,10 @@ class HuntsmanObservatory(Observatory):
                     n_good_exposures[cam_name] += 1
                 self.logger.debug(f'Current acceptable flat-field exposures for {cam_name} '
                                   f'in {observation.filter_name} filter after {attempt_number + 1} '
-                                  f'attempts: {n_good_exposures[cam_name]} of {max_num_exposures}.')
+                                  f'attempts: {n_good_exposures[cam_name]} of {required_exposures}.')
 
                 # Check if we have enough good flats for this camera
-                if n_good_exposures[cam_name] >= max_num_exposures:
+                if n_good_exposures[cam_name] >= required_exposures:
                     self.logger.debug('Enough acceptable flat-field exposures acquired for '
                                       f'{cam_name} in {observation.filter_name} filter.')
                     finished[cam_name] = True

--- a/src/huntsman/pocs/tests/test_observatory.py
+++ b/src/huntsman/pocs/tests/test_observatory.py
@@ -92,4 +92,4 @@ def test_take_flat_fields(pocs):
     assert pocs.observatory.is_dark(horizon='flat') is True
     pocs.initialize()
     pocs.get_ready()
-    pocs.observatory.take_flat_fields(alt=60, az=90, max_num_exposures=1, tolerance=0.5)
+    pocs.observatory.take_flat_fields(alt=60, az=90, required_exposures=1, tolerance=0.5)


### PR DESCRIPTION
Small changes to the default `huntsman.yaml` config file:
- Specify the min exposure time
- Rename max_num_exposures

Also remove next exptime rounding in observatory method to allow exptimes < 1s.