### PR TITLE
Use IP as default pyro service host

### DIFF
--- a/scripts/testing/run_docker_tests.sh
+++ b/scripts/testing/run_docker_tests.sh
@@ -29,7 +29,7 @@ huntsman-pyro --verbose --host "${PYRO_NS_HOST}" --port "${PYRO_NS_PORT}" namese
 # Start a pyro camera service
 # TODO: Move inside conftest
 echo "Creating testing Pyro CameraService"
-huntsman-pyro --verbose service --service-name dslr.00 --service-class huntsman.pocs.camera.pyro.service.CameraService &
+huntsman-pyro --verbose --host 0.0.0.0 service --service-name dslr.00 --service-class huntsman.pocs.camera.pyro.service.CameraService &
 
 # Run the tests
 echo "Starting testing"

--- a/src/huntsman/pocs/utils/pyro/service.py
+++ b/src/huntsman/pocs/utils/pyro/service.py
@@ -1,4 +1,3 @@
-from functools import partial
 from multiprocessing import Process
 
 import Pyro5.errors
@@ -6,9 +5,11 @@ from Pyro5.api import Daemon as PyroDaemon
 
 from panoptes.utils.config.client import set_config
 from panoptes.utils.library import load_module
+
 from huntsman.pocs.utils.config import get_config
 from huntsman.pocs.utils.logger import logger
 from huntsman.pocs.utils.pyro.nameserver import get_running_nameserver
+from huntsman.pocs.utils.config import get_own_ip
 
 
 def pyro_service(service_class=None,
@@ -39,7 +40,9 @@ def pyro_service(service_class=None,
             but still return the completed process.
     """
     # Specify address
-    host = host or get_config(f'pyro.{service_name}.ip', default='0.0.0.0')
+    host = host or get_config(f'pyro.{service_name}.ip', default=None)
+    if host is None:
+        host = get_own_ip(verbose=True)
     # If port is not in config set to 0 so that Pyro will choose a random one.
     port = int(port or get_config(f'pyro.{service_name}.port', default=0))
     # Specify metadata to be stored on NS


### PR DESCRIPTION
The current default is 0.0.0.0, which means the cameras register with 0.0.0.0 as the IP in the Pyro URI, meaning we can't connect to them from the control computer.