### PR TITLE
Parse camera config when creating distributed cameras

### DIFF
--- a/src/huntsman/pocs/camera/utils.py
+++ b/src/huntsman/pocs/camera/utils.py
@@ -125,7 +125,7 @@ def create_distributed_cameras(camera_config, metadata=None):
     primary_id = camera_config.get('primary', '')
     for cam_name, cam_uri in camera_uris.items():
         logger.debug(f'Creating camera: {cam_name}')
-        cam = Camera(port=cam_name, uri=cam_uri)
+        cam = Camera(port=cam_name, uri=cam_uri, **camera_config)
 
         if primary_id == cam.uid or primary_id == cam.name:
             cam.is_primary = True


### PR DESCRIPTION
- Currently the camera config is not parsed to pyro camera clients, meaning we cannot control things like temperature tolerance
- Parse camera config when creating distributed cameras