### PR TITLE
Mount docker logs

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -78,6 +78,6 @@ services:
       HUNTSMAN_POCS: /var/huntsman
       PANDIR: /var/panoptes
       POCS: /var/panoptes/POCS
-    command: ipython
+    command: /bin/bash
     volumes:
       - panlog:/var/huntsman/logs

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,5 +1,15 @@
 version: '3.3'
+
+volumes:
+  panlog:
+    driver: local
+    driver_opts:
+    type: none
+    device: ${PANDIR}/logs
+    o: bind
+
 services:
+
   pocs-config-server:
     image: huntsmanarray/huntsman-pocs:develop
     tty: true
@@ -15,6 +25,9 @@ services:
     volumes:
       - "${PANOPTES_CONFIG_FILE}:/var/huntsman/huntsman-pocs/conf_files/huntsman.yaml"
     command: [ "panoptes-config-server --verbose run --config-file /var/huntsman/huntsman-pocs/conf_files/huntsman.yaml" ]
+    volumes:
+      - panlog:/var/huntsman/logs
+
   pyro-name-server:
     image: huntsmanarray/huntsman-pocs:develop
     tty: true
@@ -31,6 +44,9 @@ services:
       POCS: /var/panoptes/POCS
       PANOPTES_CONFIG_PORT: 6563
     command: [ "/var/panoptes/POCS/scripts/wait-for-it.sh localhost:6563 -- huntsman-pyro nameserver --auto-clean 90" ]
+    volumes:
+      - panlog:/var/huntsman/logs
+
   pyro-http:
     image: huntsmanarray/huntsman-pocs:develop
     tty: true
@@ -47,3 +63,21 @@ services:
       POCS: /var/panoptes/POCS
       PANOPTES_CONFIG_PORT: 6563
     command: [ "/var/panoptes/POCS/scripts/wait-for-it.sh localhost:6564 -- pyro5-httpgateway -e '.*'" ]
+    volumes:
+      - panlog:/var/huntsman/logs
+
+  pocs-control:
+    image: huntsmanarray/huntsman-pocs:develop
+    tty: true
+    container_name: pocs-control
+    hostname: pocs-control
+    privileged: true
+    network_mode: host
+    restart: on-failure
+    environment:
+      HUNTSMAN_POCS: /var/huntsman
+      PANDIR: /var/panoptes
+      POCS: /var/panoptes/POCS
+    command: ipython
+    volumes:
+      - panlog:/var/huntsman/logs

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -62,7 +62,7 @@ services:
       PANDIR: /var/panoptes
       POCS: /var/panoptes/POCS
       PANOPTES_CONFIG_PORT: 6563
-    command: [ "/var/panoptes/POCS/scripts/wait-for-it.sh localhost:6564 -- pyro5-httpgateway -e '.*'" ]
+    command: [ "/var/panoptes/POCS/scripts/wait-for-it.sh localhost:6564 -- pyro5-httpgateway -p 8081 -e '.*'" ]
     volumes:
       - panlog:/var/huntsman/logs
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -24,9 +24,8 @@ services:
     restart: on-failure
     volumes:
       - "${PANOPTES_CONFIG_FILE}:/var/huntsman/huntsman-pocs/conf_files/huntsman.yaml"
-    command: [ "panoptes-config-server --verbose run --config-file /var/huntsman/huntsman-pocs/conf_files/huntsman.yaml" ]
-    volumes:
       - panlog:/var/huntsman/logs
+    command: [ "panoptes-config-server --verbose run --config-file /var/huntsman/huntsman-pocs/conf_files/huntsman.yaml" ]
 
   pyro-name-server:
     image: huntsmanarray/huntsman-pocs:develop
@@ -62,9 +61,9 @@ services:
       PANDIR: /var/panoptes
       POCS: /var/panoptes/POCS
       PANOPTES_CONFIG_PORT: 6563
-    command: [ "/var/panoptes/POCS/scripts/wait-for-it.sh localhost:6564 -- pyro5-httpgateway -p 8081 -e '.*'" ]
     volumes:
       - panlog:/var/huntsman/logs
+    command: [ "/var/panoptes/POCS/scripts/wait-for-it.sh localhost:6564 -- pyro5-httpgateway -p 8081 -e '.*'" ]
 
   huntsman-control:
     image: huntsmanarray/huntsman-pocs:develop
@@ -78,6 +77,6 @@ services:
       HUNTSMAN_POCS: /var/huntsman
       PANDIR: /var/panoptes
       POCS: /var/panoptes/POCS
-    command: /bin/bash
     volumes:
       - panlog:/var/huntsman/logs
+    command: /bin/bash

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -4,9 +4,9 @@ volumes:
   panlog:
     driver: local
     driver_opts:
-    type: none
-    device: ${PANDIR}/logs
-    o: bind
+      type: none
+      device: ${PANDIR}/logs
+      o: bind
 
 services:
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -9,7 +9,6 @@ volumes:
       o: bind
 
 services:
-
   pocs-config-server:
     image: huntsmanarray/huntsman-pocs:develop
     tty: true
@@ -26,7 +25,6 @@ services:
       - "${PANOPTES_CONFIG_FILE}:/var/huntsman/huntsman-pocs/conf_files/huntsman.yaml"
       - panlog:/var/huntsman/logs
     command: [ "panoptes-config-server --verbose run --config-file /var/huntsman/huntsman-pocs/conf_files/huntsman.yaml" ]
-
   pyro-name-server:
     image: huntsmanarray/huntsman-pocs:develop
     tty: true
@@ -45,7 +43,6 @@ services:
     command: [ "/var/panoptes/POCS/scripts/wait-for-it.sh localhost:6563 -- huntsman-pyro nameserver --auto-clean 90" ]
     volumes:
       - panlog:/var/huntsman/logs
-
   pyro-http:
     image: huntsmanarray/huntsman-pocs:develop
     tty: true
@@ -64,19 +61,3 @@ services:
     volumes:
       - panlog:/var/huntsman/logs
     command: [ "/var/panoptes/POCS/scripts/wait-for-it.sh localhost:6564 -- pyro5-httpgateway -p 8081 -e '.*'" ]
-
-  huntsman-control:
-    image: huntsmanarray/huntsman-pocs:develop
-    tty: true
-    container_name: huntsman-control
-    hostname: huntsman-control
-    privileged: true
-    network_mode: host
-    restart: on-failure
-    environment:
-      HUNTSMAN_POCS: /var/huntsman
-      PANDIR: /var/panoptes
-      POCS: /var/panoptes/POCS
-    volumes:
-      - panlog:/var/huntsman/logs
-    command: /bin/bash

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -66,11 +66,11 @@ services:
     volumes:
       - panlog:/var/huntsman/logs
 
-  pocs-control:
+  huntsman-control:
     image: huntsmanarray/huntsman-pocs:develop
     tty: true
-    container_name: pocs-control
-    hostname: pocs-control
+    container_name: huntsman-control
+    hostname: huntsman-control
     privileged: true
     network_mode: host
     restart: on-failure

--- a/src/huntsman/pocs/camera/pyro/client.py
+++ b/src/huntsman/pocs/camera/pyro/client.py
@@ -45,6 +45,7 @@ class Camera(AbstractCamera):
         self.port = port
         self.is_primary = primary
         self._timeout = get_quantity_value(kwargs.get('timeout', 10), unit=u.second)
+        self.subcomponents = dict()  # Required for "stringifying" the camera
 
         # The proxy used for communication with the remote instance.
         self._uri = uri


### PR DESCRIPTION
- Current control computer logs are only accessible from inside docker image
- This PR mounts the log directory so the logs are easily accessible from the control comp outside of docker
- Minor camera fix to allow a pyro camera instance to be "stringified"
- Pyro http server runs on port 8081 to avoid clash with lights