### PR TITLE
Added changes that were tested in the last DWF run for the taking_darks state

### DIFF
--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -8,7 +8,7 @@ from astropy import stats
 from astropy import units as u
 from astropy.io import fits
 
-from panoptes.utils import error, altaz_to_radec, listify
+from panoptes.utils import error, altaz_to_radec, listify, get_quantity_value
 from panoptes.utils.library import load_module
 from panoptes.utils.time import current_time, flatten_time, wait_for_events
 

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -321,8 +321,9 @@ class HuntsmanObservatory(Observatory):
             n_darks = listify(n_darks) * len(exptimes)
 
         if set_from_config:
-            exptimes = self.config["calibration"]["darks"]["exposure_time"]
-            n_darks = self.config["calibration"]["darks"]["n_darks"]
+            dark_config = self.get_config('calibration', default=dict())
+            exptimes = dark_config["darks"]["exposure_time"]
+            n_darks = dark_config["darks"]["n_darks"]
 
         self.logger.debug(f"Going to take {n_darks} dark-fields for each of these exposure times {exptimes}")
 

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -268,8 +268,7 @@ class HuntsmanObservatory(Observatory):
         self.logger.info('Finished flat-fielding.')
 
     def take_dark_images(self,
-                         exptimes=[],
-                         sleep=10,
+                         exptimes=None,
                          camera_names=None,
                          n_darks=10,
                          imtype='dark',

--- a/src/huntsman/pocs/scheduler/dark_observation.py
+++ b/src/huntsman/pocs/scheduler/dark_observation.py
@@ -12,8 +12,8 @@ class DarkObservation(Observation):
     """ A Dark observation
 
     Dark observations will consist of multiple exposure. As the mount will be
-    parked when using this class, the fields will be centred at the parked
-    position.
+    parked when using this class, the fits image header RA, Dec will be centred
+    at the parked position.
 
     Note:
         For now the new observation must be created like a normal `Observation`,

--- a/src/huntsman/pocs/scheduler/dark_observation.py
+++ b/src/huntsman/pocs/scheduler/dark_observation.py
@@ -1,3 +1,4 @@
+import os
 from astropy import units as u
 from contextlib import suppress
 
@@ -7,6 +8,7 @@ from panoptes.utils import listify
 
 
 class DarkObservation(Observation):
+
     """ A Dark-field observation
 
     Dark observations will consist of multiple exposure. As the mount will be
@@ -35,6 +37,9 @@ class DarkObservation(Observation):
         self._field = listify(self.field)
 
         self.extra_config = kwargs
+
+        # Specify directory root for file storage
+        self._directory = os.path.join(self._image_dir, 'darks')
 
     @property
     def exptime(self):

--- a/src/huntsman/pocs/scheduler/dark_observation.py
+++ b/src/huntsman/pocs/scheduler/dark_observation.py
@@ -9,7 +9,7 @@ from panoptes.utils import listify
 
 class DarkObservation(Observation):
 
-    """ A Dark-field observation
+    """ A Dark observation
 
     Dark observations will consist of multiple exposure. As the mount will be
     parked when using this class, the fields will be centred at the parked
@@ -29,8 +29,8 @@ class DarkObservation(Observation):
                 `~astropy.coordinates.SkyCoord`.
         """
         # Create the observation
-        dark_field = Field('Dark-Field', position)
-        super().__init__(field=dark_field, *args, **kwargs)
+        dark_image = Field('Dark', position)
+        super().__init__(field=dark_image, *args, **kwargs)
 
         # Set initial list to original values
         self._exptime = listify(self.exptime)

--- a/src/huntsman/pocs/states/huntsman/taking_darks.py
+++ b/src/huntsman/pocs/states/huntsman/taking_darks.py
@@ -7,8 +7,6 @@ def on_enter(event_data):
 
         pocs.say("It's time to take darks!")
 
-        pocs.status
-
         # Wait until mount is parked
         pocs.say("Everything set up for dark fields")
 

--- a/src/huntsman/pocs/states/huntsman/taking_darks.py
+++ b/src/huntsman/pocs/states/huntsman/taking_darks.py
@@ -23,7 +23,7 @@ def on_enter(event_data):
             pocs.observatory.take_dark_fields(exptimes_list)
 
         else:
-            pocs.say("No exposure times provided. Going to housekeeping.")
+            pocs.say("No exposure times were provided. Going to housekeeping.")
 
     except Exception as e:
         pocs.logger.warning("Problem encountered while taking darks: {}".format(e))

--- a/src/huntsman/pocs/states/huntsman/taking_darks.py
+++ b/src/huntsman/pocs/states/huntsman/taking_darks.py
@@ -23,7 +23,7 @@ def on_enter(event_data):
             pocs.observatory.take_dark_fields(exptimes_list)
 
         else:
-            pocs.say("No exposure times were provided. Going to housekeeping.")
+            pocs.say("No exposure times were provided. Going to housekeeping state.")
 
     except Exception as e:
         pocs.logger.warning("Problem encountered while taking darks: {}".format(e))

--- a/src/huntsman/pocs/states/huntsman/taking_darks.py
+++ b/src/huntsman/pocs/states/huntsman/taking_darks.py
@@ -8,7 +8,7 @@ def on_enter(event_data):
         pocs.say("It's time to take darks!")
 
         # Wait until mount is parked
-        pocs.say("Everything set up for dark fields")
+        pocs.say("Everything set up for darks")
 
         exptimes_list = list()
         for target in pocs.observatory.scheduler.fields_list:
@@ -16,14 +16,12 @@ def on_enter(event_data):
             if exptime not in exptimes_list:
                 exptimes_list.append(exptime)
 
-        if len(exptimes_list) > 0:
-            pocs.say("I'm starting with dark-field exposures")
-            pocs.observatory.take_dark_fields(exptimes_list)
-
-        else:
-            pocs.say("No exposure times were provided. Going to housekeeping state.")
+        pocs.say("I'm starting with dark exposures")
+        pocs.observatory.take_dark_images(exptimes_list)
 
     except Exception as e:
         pocs.logger.warning("Problem encountered while taking darks: {}".format(e))
 
-    pocs.next_state = 'housekeeping'
+    finally:
+        pocs.say("Going to housekeeping state.")
+        pocs.next_state = 'housekeeping'

--- a/src/huntsman/pocs/states/huntsman/taking_darks.py
+++ b/src/huntsman/pocs/states/huntsman/taking_darks.py
@@ -7,7 +7,7 @@ def on_enter(event_data):
 
         pocs.say("It's time to take darks!")
 
-        pocs.status()
+        pocs.status
 
         # Wait until mount is parked
         pocs.say("Everything set up for dark fields")
@@ -18,9 +18,10 @@ def on_enter(event_data):
             if exptime not in exptimes_list:
                 exptimes_list.append(exptime)
 
-            if len(exptimes_list) > 0:
-                pocs.say("I'm starting with dark-field exposures")
-                pocs.observatory.take_dark_fields(exptimes_list)
+        if len(exptimes_list) > 0:
+            pocs.say("I'm starting with dark-field exposures")
+            pocs.observatory.take_dark_fields(exptimes_list)
+
     except Exception as e:
         pocs.logger.warning("Problem encountered while taking darks: {}".format(e))
 

--- a/src/huntsman/pocs/states/huntsman/taking_darks.py
+++ b/src/huntsman/pocs/states/huntsman/taking_darks.py
@@ -22,6 +22,9 @@ def on_enter(event_data):
             pocs.say("I'm starting with dark-field exposures")
             pocs.observatory.take_dark_fields(exptimes_list)
 
+        else:
+            pocs.say("No exposure times provided. Going to housekeeping.")
+
     except Exception as e:
         pocs.logger.warning("Problem encountered while taking darks: {}".format(e))
 


### PR DESCRIPTION
Hi,

This PR includes all the changes that were made to the `taking_darks` state during the last DWF run in September, and they were used to collect a significant number of dark images. Main changes include:

- Move all filterwheels to `blank` position in `take_dark_fields` before exposing.
- Fixed bug in `taking_darks` state to grab the list of exposure times from `targets.yaml`.

All unit tests are passing successfully and all the changes have already been tested with real hardware. Everything is up-to-date with the latest `POCS` version.

Please let me know any comment or suggestion.

Cheers,
Jaime A.