### PR TITLE
Move all filterwheels to the luminance filter before focusing

### DIFF
--- a/conf_files/huntsman.yaml
+++ b/conf_files/huntsman.yaml
@@ -71,7 +71,7 @@ flat_fields:
   min_exptime: 0.0001
 
 darks:
-  exposure_times: [10, 30, 60, 300]
+  exposure_time: [10, 30, 60, 300]
   n_darks: 5
 
 pointing:

--- a/conf_files/huntsman.yaml
+++ b/conf_files/huntsman.yaml
@@ -70,6 +70,10 @@ flat_fields:
   max_exptime: 60
   min_exptime: 0.0001
 
+darks:
+  exposure_times: [10, 30, 60, 300]
+  n_darks: 5
+
 pointing:
     exptime: 30
     max_iterations: 3
@@ -86,6 +90,7 @@ focusing:
     frequency: 2
     frequency_unit: hour
     timeout: 600
+    filter_name: luminance
 
 pyro:
     nameserver:

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -53,9 +53,9 @@ class HuntsmanObservatory(Observatory):
 
         # Attributes for focusing
         self.last_focus_time = None
-        coarse_focus_config = self.get_config('focusing.coarse')
-        self._focus_frequency = coarse_focus_config['frequency'] \
-            * u.Unit(coarse_focus_config['frequency_unit'])
+        self.coarse_focus_config = self.get_config('focusing.coarse')
+        self._focus_frequency = self.coarse_focus_config['frequency'] \
+            * u.Unit(self.coarse_focus_config['frequency_unit'])
 
         if self.has_autoguider:
             self.logger.info("Setting up autoguider")
@@ -140,7 +140,7 @@ class HuntsmanObservatory(Observatory):
         """
 
         # Move all the filterwheels to the luminance position.
-        self._move_all_filterwheels_to('luminance')
+        self._move_all_filterwheels_to(self.coarse_focus_config['filter_name'])
 
         result = super().autofocus_cameras(*args, **kwargs)
 
@@ -275,13 +275,13 @@ class HuntsmanObservatory(Observatory):
 
         exptimes = listify(exptimes)
 
-        if not isinstance(n_darks, list):
-            n_darks = listify(n_darks) * len(exptimes)
-
         if set_from_config:
-            dark_config = self.get_config('calibs.dark', default=dict())
+            dark_config = self.get_config('darks', default=dict())
             exptimes = dark_config['exposure_time']
             n_darks = dark_config['n_darks']
+
+        if not isinstance(n_darks, list):
+            n_darks = listify(n_darks) * len(exptimes)
 
         # Loop over cameras.
         if len(exptimes) == 0:

--- a/src/huntsman/pocs/states/huntsman/focusing.py
+++ b/src/huntsman/pocs/states/huntsman/focusing.py
@@ -1,6 +1,6 @@
 from time import sleep
 
-wait_interval = 15.
+WAIT_INTERVAL = 15
 
 
 def on_enter(event_data):
@@ -20,9 +20,10 @@ def on_enter(event_data):
         while not all([event.is_set() for event in camera_events.values()]):
             pocs.logger.debug('Waiting for images: {} seconds'.format(wait_time))
 
-            sleep(wait_interval)
-            wait_time += wait_interval
+            sleep(WAIT_INTERVAL)
+            wait_time += WAIT_INTERVAL
 
+        pocs.logger.info("Finished fine focusing, setting next state to 'observing'.")
         pocs.next_state = 'observing'
 
     except Exception as e:


### PR DESCRIPTION
Hi everyone,

This PR adds a new private method that can be used to move ALL the filterwheels to a given filter. 

This new function is used now inside `autofocus_cameras` to move all the filterwheels to the `luminance` filter before focusing, which is needed during the `coarse_focusing` and `focusing` states. Also, this new function has replaced a piece of repeated code inside the `take_dark_images` method to move all the filterwheels to the `blank` position.

Please let me know any suggestion or comment. Thanks!

Cheers,
Jaime A.