### PR TITLE
Add option to skip solve WCS during analyzing_image

### DIFF
--- a/conf_files/huntsman.yaml
+++ b/conf_files/huntsman.yaml
@@ -97,3 +97,12 @@ pyro:
       host: localhost
         port: 0
     devices: []
+
+observations:
+  make_timelapse: False
+  compress_fits: False
+  record_observations: True
+  make_pretty_images: False
+  keep_jpgs: False
+  analyze_recent_offset: False
+

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -131,7 +131,8 @@ class HuntsmanObservatory(Observatory):
             self.logger.debug(f'Pointing image set to {self.current_observation.pointing_image}')
 
         # Now call the main analyze
-        super().analyze_recent()
+        if self.get_config('observations.analyze_recent_offset', default=True):
+            super().analyze_recent()
 
         return self.current_offset_info
 


### PR DESCRIPTION
Solving for WCS may not be needed in all cases, so adding a configuration option to disable it. By default it will still happen.

Simply added an option `observations.analyize_recent_offset`. When set to False (not the default), it will skip the WCS solve field step after an image is taking.