### PR TITLE
Wait for config server and docker memory

### DIFF
--- a/docker/camera/docker-compose.yaml
+++ b/docker/camera/docker-compose.yaml
@@ -10,6 +10,12 @@ services:
       PANDIR: /var/huntsman
       PANOPTES_CONFIG_HOST:
       PANOPTES_CONFIG_PORT:
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+        reservations:
+          memory: 320M
     command: [ "huntsman-pyro --verbose service --service-class huntsman.pocs.camera.pyro.service.CameraService" ]
     volumes:
       - "${PANDIR}/images:/var/huntsman/images"

--- a/docker/camera/docker-compose.yaml
+++ b/docker/camera/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1G
+          memory: 960M
         reservations:
           memory: 320M
     command: [ "huntsman-pyro --verbose service --service-class huntsman.pocs.camera.pyro.service.CameraService" ]

--- a/scripts/camera/run-camera-service.sh
+++ b/scripts/camera/run-camera-service.sh
@@ -49,4 +49,4 @@ docker system prune -f
 echo "Downloading latest docker image(s)..."
 docker-compose -f ${DC_FILE} pull
 echo "Starting the camera docker service..."
-docker-compose -f ${DC_FILE} run camera
+docker-compose -f ${DC_FILE} --compatibility run camera

--- a/src/huntsman/pocs/camera/pyro/service.py
+++ b/src/huntsman/pocs/camera/pyro/service.py
@@ -4,7 +4,7 @@ from threading import Event, Thread
 from contextlib import suppress
 import Pyro5.server
 
-from panoptes.utils.config.client import get_config, server_is_running
+from panoptes.utils.config.client import get_config
 from panoptes.utils.library import load_module
 
 from huntsman.pocs.utils.logger import logger
@@ -31,10 +31,7 @@ class CameraService(object):
         # Fetch the config once during object creation
         # TODO determine if we want to make all config calls dynamic.
 
-        self.logger.info("Getting camera config from config server.")
-        while not server_is_running():
-            self.logger.debug("Waiting for config server to start up.")
-            time.sleep(1)
+        self.logger.debug("Getting camera config from config server.")
         self.config = get_config()
 
         self.host = self.config.get('host')

--- a/src/huntsman/pocs/utils/pyro/service.py
+++ b/src/huntsman/pocs/utils/pyro/service.py
@@ -1,12 +1,9 @@
-from multiprocessing import Process
-
-import Pyro5.errors
+import time
 from Pyro5.api import Daemon as PyroDaemon
 
-from panoptes.utils.config.client import set_config
 from panoptes.utils.library import load_module
+from panoptes.utils.config.client import get_config, server_is_running
 
-from huntsman.pocs.utils.config import get_config
 from huntsman.pocs.utils.logger import logger
 from huntsman.pocs.utils.pyro.nameserver import get_running_nameserver
 from huntsman.pocs.utils.config import get_own_ip
@@ -37,6 +34,10 @@ def pyro_service(service_class=None,
             service was started via `autostart=True`, the function will block until terminated,
             but still return the completed process.
     """
+    while not server_is_running():
+        logger.debug("Waiting for config server to start up before starting pyro service.")
+        time.sleep(5)
+
     # Specify address
     host = host or get_config(f'pyro.{service_name}.ip', default=None)
     if host is None:


### PR DESCRIPTION
- Moves the wait for config block into the pyro service function, allowing cameras to properly register with the name server after waiting for the config server to start (tested on Huntsman)
- Adds hard and soft memory limits to the docker container. Hopefully this will help some of the memory issues.