### PR TITLE
Add swap to cloud-init

### DIFF
--- a/docker/camera/docker-compose.yaml
+++ b/docker/camera/docker-compose.yaml
@@ -13,10 +13,10 @@ services:
     deploy:
       resources:
         limits:
-          memory: 704M
-          memory-swap: 1G
+          memory: 960M
+          memory-swap: 1280M
         reservations:
-          memory: 320M
+          memory: 512M
     command: [ "huntsman-pyro --verbose service --service-class huntsman.pocs.camera.pyro.service.CameraService" ]
     volumes:
       - "${PANDIR}/images:/var/huntsman/images"

--- a/docker/camera/docker-compose.yaml
+++ b/docker/camera/docker-compose.yaml
@@ -10,13 +10,6 @@ services:
       PANDIR: /var/huntsman
       PANOPTES_CONFIG_HOST:
       PANOPTES_CONFIG_PORT:
-    deploy:
-      resources:
-        limits:
-          memory: 960M
-          memory-swap: 1280M
-        reservations:
-          memory: 512M
     command: [ "huntsman-pyro --verbose service --service-class huntsman.pocs.camera.pyro.service.CameraService" ]
     volumes:
       - "${PANDIR}/images:/var/huntsman/images"

--- a/docker/camera/docker-compose.yaml
+++ b/docker/camera/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2.4'
 services:
   camera:
     image: huntsmanarray/huntsman-pocs-camera:develop
@@ -10,12 +10,10 @@ services:
       PANDIR: /var/huntsman
       PANOPTES_CONFIG_HOST:
       PANOPTES_CONFIG_PORT:
-    deploy:
-      resources:
-        limits:
-          memory: 960M
-        reservations:
-          memory: 320M
+    mem_limit: 704M
+    memswap_limit: 1G
+    mem_swappiness: 1
+    mem_reservation: 320M
     command: [ "huntsman-pyro --verbose service --service-class huntsman.pocs.camera.pyro.service.CameraService" ]
     volumes:
       - "${PANDIR}/images:/var/huntsman/images"

--- a/docker/camera/docker-compose.yaml
+++ b/docker/camera/docker-compose.yaml
@@ -12,7 +12,6 @@ services:
       PANOPTES_CONFIG_PORT:
     deploy:
       resources:
-        memory-swappiness: 1
         limits:
           memory: 704M
           memory-swap: 1G

--- a/docker/camera/docker-compose.yaml
+++ b/docker/camera/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '2.4'
+version: '3.7'
 services:
   camera:
     image: huntsmanarray/huntsman-pocs-camera:develop
@@ -10,10 +10,14 @@ services:
       PANDIR: /var/huntsman
       PANOPTES_CONFIG_HOST:
       PANOPTES_CONFIG_PORT:
-    mem_limit: 704M
-    memswap_limit: 1G
-    mem_swappiness: 1
-    mem_reservation: 320M
+    deploy:
+      resources:
+        memory-swappiness: 1
+        limits:
+          memory: 704M
+          memory-swap: 1G
+        reservations:
+          memory: 320M
     command: [ "huntsman-pyro --verbose service --service-class huntsman.pocs.camera.pyro.service.CameraService" ]
     volumes:
       - "${PANDIR}/images:/var/huntsman/images"

--- a/scripts/camera/install-camera-pi.sh
+++ b/scripts/camera/install-camera-pi.sh
@@ -64,14 +64,14 @@ export PANDIR=/var/huntsman
 EOF
 }
 
-# Make a swap file and set swappiness to 0
+# Make a swap file and set swappiness to 1
 # https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-20-04
 function setup_swap() {
   fallocate -l 320M /swapfile
   chmod 600 /swapfile
   mkswap /swapfile
   echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
-  echo 'vm.swappiness=0' >> /etc/sysctl.conf
+  echo 'vm.swappiness=1' >> /etc/sysctl.conf
 }
 
 function enable_auto_login() {

--- a/scripts/camera/install-camera-pi.sh
+++ b/scripts/camera/install-camera-pi.sh
@@ -67,7 +67,7 @@ EOF
 # Make a swap file and set swappiness to 0
 # https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-20-04
 function setup_swap() {
-  fallocate -l 300M /swapfile
+  fallocate -l 320M /swapfile
   chmod 600 /swapfile
   mkswap /swapfile
   echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab

--- a/scripts/camera/install-camera-pi.sh
+++ b/scripts/camera/install-camera-pi.sh
@@ -64,6 +64,16 @@ export PANDIR=/var/huntsman
 EOF
 }
 
+# Make a swap file and set swappiness to 0
+# https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-20-04
+function setup_swap() {
+  fallocate -l 300M /swapfile
+  chmod 600 /swapfile
+  mkswap /swapfile
+  echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+  echo 'vm.swappiness=0' >> /etc/sysctl.conf
+}
+
 function enable_auto_login() {
   # Set up autologin without password for huntsman user
   # This is a bit of a hack but it appears to be the standard method of doing this
@@ -121,6 +131,9 @@ function do_install() {
 
  echo "Installing system dependencies..."
  system_deps
+
+ echo "Setting up swap..."
+ setup_swap
 
  echo "Setting up auto-login..."
  enable_auto_login


### PR DESCRIPTION
Adds a small swap file (320Mb) and sets `swapiness` to 1. Let the host govern memory limits for the docker container.