### PR TITLE
override initial_next_state default in POCS.run

### DIFF
--- a/src/huntsman/pocs/core.py
+++ b/src/huntsman/pocs/core.py
@@ -1,0 +1,19 @@
+from panoptes.pocs.core import POCS
+
+
+class HuntsmanPOCS(POCS):
+    """ Minimal overrides to the POCS class """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def run(self, initial_next_state='initialising', *args, **kwargs):
+        """ Override the default initial_next_state parameter from "ready" to "initialising".
+        This allows us to call pocs.run() as normal, without needing to specify the initial next
+        state explicitly.
+        Args:
+            initial_next_state (str, optional): The first state the machine should move to from
+                the `sleeping` state, default `ready`.
+            *args, **kwargs: Parsed to POCS.run.
+        """
+        return super().run(initial_next_state=initial_next_state, *args, **kwargs)

--- a/src/huntsman/pocs/tests/test_states.py
+++ b/src/huntsman/pocs/tests/test_states.py
@@ -68,6 +68,7 @@ def test_startup(pocs):
     pocs.goto_next_state()
     assert pocs.state == "starting"
 
+
 def test_starting_sleeping(pocs):
     '''
     Test if the parking state transitions back into ready.

--- a/src/huntsman/pocs/tests/test_states.py
+++ b/src/huntsman/pocs/tests/test_states.py
@@ -3,13 +3,13 @@ import pytest
 
 from panoptes.utils import current_time
 
-from panoptes.pocs.core import POCS
 from panoptes.pocs.utils.location import create_location_from_config
 from panoptes.pocs.scheduler import create_scheduler_from_config
 from panoptes.pocs.mount import create_mount_simulator
 from panoptes.utils.config.client import set_config
 from panoptes.pocs.dome import create_dome_simulator
 
+from huntsman.pocs.core import HuntsmanPOCS
 from huntsman.pocs.camera.utils import create_cameras_from_config
 from huntsman.pocs.observatory import HuntsmanObservatory as Observatory
 
@@ -48,7 +48,7 @@ def dome():
 @pytest.fixture(scope='function')
 def pocs(observatory, dome):
     os.environ['POCSTIME'] = '2020-01-01 08:00:00'
-    pocs = POCS(observatory, run_once=True)
+    pocs = HuntsmanPOCS(observatory, run_once=True)
     pocs.observatory.set_dome(dome)
     yield pocs
     pocs.power_down()
@@ -56,6 +56,17 @@ def pocs(observatory, dome):
 
 # ==============================================================================
 
+def test_startup(pocs):
+    """ Test if we are able to start up properly.
+    """
+    pocs.initialize()
+    pocs.set_config('simulator', ['camera', 'mount', 'weather', 'power', 'night'])
+    assert pocs.state == "sleeping"
+    pocs.next_state = "starting"  # Usually handled by pocs.run()
+    assert pocs.next_state == "starting"
+    assert pocs.is_safe()
+    pocs.goto_next_state()
+    assert pocs.state == "starting"
 
 def test_starting_sleeping(pocs):
     '''

--- a/src/huntsman/pocs/utils/huntsman.py
+++ b/src/huntsman/pocs/utils/huntsman.py
@@ -2,11 +2,11 @@ from panoptes.utils.config.client import get_config
 
 from panoptes.pocs.scheduler import create_scheduler_from_config
 from panoptes.pocs.mount import create_mount_from_config
-from panoptes.pocs.core import POCS
 
 from huntsman.pocs.camera.utils import create_cameras_from_config
 from huntsman.pocs.observatory import HuntsmanObservatory
 from huntsman.pocs.dome import create_dome_from_config
+from huntsman.pocs.core import HuntsmanPOCS
 
 
 def create_huntsman_observatory(with_dome=False, cameras=None, mount=None, scheduler=None,
@@ -61,7 +61,7 @@ def create_huntsman_pocs(observatory=None, simulators=['power', ], **kwargs):
     if observatory is None:
         observatory = create_huntsman_observatory(**kwargs)
 
-    pocs = POCS(observatory, simulators=simulators)
-    pocs.initialize()
+    huntsman = HuntsmanPOCS(observatory=observatory, simulators=simulators)
+    huntsman.initialize()
 
-    return pocs
+    return huntsman


### PR DESCRIPTION
- We need to go from sleeping to ready via the initialising state.
- We therefore need to change the default initial next state when running POCS.
- Added HuntsmanPOCS class with this override. The class will come in handy for overriding default state machine behaviour in future.