### PR TITLE
Switch to official docker buildx actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - develop
+  pull_request:
+    branches: 
+      - develop
 jobs:
   buildx:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,9 +3,7 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    branches: 
-      - develop
+  workflow_dispatch:
 jobs:
   buildx:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - develop
-  workflow_dispatch:
+      - switch-gha-buildx
 jobs:
   buildx:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,24 +7,29 @@ jobs:
   buildx:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout huntsman-pocs
+      -
+        name: Checkout huntsman-pocs
         uses: actions/checkout@v2
-      - name: Docker login
+      -
+        name: Docker login
         run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-      - name: Set up Docker Buildx
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
-        with:
-          buildx-version: latest
-          qemu-version: 5.1.0-2
-      - name: Build and push huntsman-pocs:develop image
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build and push huntsman-pocs:develop image
         run: |
           docker buildx build \
             -f docker/Dockerfile \
             --platform linux/arm64,linux/amd64 \
             --tag huntsmanarray/huntsman-pocs:develop \
             --output "type=image,push=true" .
-      - name: Build and push huntsman-pocs-camera image.
+      -
+        name: Build and push huntsman-pocs-camera image.
         run: |
           docker buildx build \
             -f docker/camera/Dockerfile \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
             --tag huntsmanarray/huntsman-pocs:develop \
             --output "type=image,push=true" .
       -
-        name: Build and push huntsman-pocs-camera image.
+        name: Build and push huntsman-pocs-camera image
         run: |
           docker buildx build \
             -f docker/camera/Dockerfile \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - switch-gha-buildx
 jobs:
   buildx:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Current buildx actions are unreliable
- Official docker buildx setup is now available (https://github.com/docker/setup-buildx-action)
