### PR TITLE
Stop mount tracking before slew

### DIFF
--- a/src/huntsman/pocs/mount/bisque.py
+++ b/src/huntsman/pocs/mount/bisque.py
@@ -1,0 +1,24 @@
+""" Minimal overrides to the bisque mount. """
+from panoptes.utils import error
+from panoptes.pocs.mount.bisque import Mount as BisqueMount
+
+
+class Mount(BisqueMount):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def slew_to_target(self, *args, **kwargs):
+        """
+        Override method to make sure telescope is not moving or tracking before slewing
+        to target. This can otherwise be problematic if the dome decides to move itself when
+        the slew command is given.
+        """
+        if self.is_slewing:
+            raise error.PanError("Attempted to slew to target but mount is already slewing.")
+
+        self.logger.debug("Deactivating tracking before slewing to target.")
+        self.query('stop_moving')
+        self.query('stop_tracking')
+
+        return super().slew_to_target(*args, **kwargs)

--- a/src/huntsman/pocs/mount/bisque.py
+++ b/src/huntsman/pocs/mount/bisque.py
@@ -1,6 +1,15 @@
 """ Minimal overrides to the bisque mount. """
+import time
+
 from panoptes.utils import error
 from panoptes.pocs.mount.bisque import Mount as BisqueMount
+from panoptes.pocs.utils.location import create_location_from_config
+
+
+def create_mount():
+    """ Placeholder until the normal function is working from POCS. """
+    location = create_location_from_config()['earth_location']
+    return Mount(location=location)
 
 
 class Mount(BisqueMount):
@@ -20,5 +29,6 @@ class Mount(BisqueMount):
         self.logger.debug("Deactivating tracking before slewing to target.")
         self.query('stop_moving')
         self.query('stop_tracking')
+        time.sleep(10)
 
         return super().slew_to_target(*args, **kwargs)

--- a/src/huntsman/pocs/utils/huntsman.py
+++ b/src/huntsman/pocs/utils/huntsman.py
@@ -1,7 +1,8 @@
 from panoptes.utils.config.client import get_config
 
 from panoptes.pocs.scheduler import create_scheduler_from_config
-from panoptes.pocs.mount import create_mount_from_config
+# from panoptes.pocs.mount import create_mount_from_config
+from huntsman.pocs.mount.bisque import create_mount
 
 from huntsman.pocs.camera.utils import create_cameras_from_config
 from huntsman.pocs.observatory import HuntsmanObservatory
@@ -30,7 +31,7 @@ def create_huntsman_observatory(with_dome=False, cameras=None, mount=None, sched
         cameras = create_cameras_from_config(config=config)
 
     if mount is None:
-        mount = create_mount_from_config()   # TODO: Parse config
+        mount = create_mount()   # TODO: Parse config
     mount.initialize()
 
     if scheduler is None:


### PR DESCRIPTION
Stop mount tracking to stop potential for dome to be moving (to catch up with mount) when slew command is issued, resulting in a skyX error.