### PR TITLE
Skip filters during flat fields if too dark/bright

### DIFF
--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -551,6 +551,20 @@ class HuntsmanObservatory(Observatory):
                 status["filter_name"] = observation.filter_name
                 self.logger.info(f"Flat field status for {cam_name}: {status}")
 
+            # Check if we need to terminate the sequence early
+            if self.past_midnight:  # Sky getting brighter
+                if all([s.is_too_bright & s.min_exptime_reached for s in sequences]):
+                    self.logger.info("Terminating flat field sequence for the "
+                                     f"{observation.filter_name} filter because all exposures are"
+                                     " too bright at the minimum exposure time.")
+                    return
+            else:  # Sky getting fainter
+                if all([s.is_too_faint & s.max_exptime_reached for s in sequences]):
+                    self.logger.info("Terminating flat field sequence for the "
+                                     f"{observation.filter_name} filter because all exposures are"
+                                     " too faint at the maximum exposure time.")
+                    return
+
     def _autoflat_target_counts(self, cam_name, target_scaling, scaling_tolerance):
         """ Get the target counts and tolerance for each camera.
         Args:

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -553,13 +553,13 @@ class HuntsmanObservatory(Observatory):
 
             # Check if we need to terminate the sequence early
             if self.past_midnight:  # Sky getting brighter
-                if all([s.is_too_bright and s.min_exptime_reached for s in sequences]):
+                if all([s.is_too_bright and s.min_exptime_reached for s in sequences.values()]):
                     self.logger.info("Terminating flat field sequence for the "
                                      f"{observation.filter_name} filter because all exposures are"
                                      " too bright at the minimum exposure time.")
                     return
             else:  # Sky getting fainter
-                if all([s.is_too_faint and s.max_exptime_reached for s in sequences]):
+                if all([s.is_too_faint and s.max_exptime_reached for s in sequences.values()]):
                     self.logger.info("Terminating flat field sequence for the "
                                      f"{observation.filter_name} filter because all exposures are"
                                      " too faint at the maximum exposure time.")

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -553,13 +553,13 @@ class HuntsmanObservatory(Observatory):
 
             # Check if we need to terminate the sequence early
             if self.past_midnight:  # Sky getting brighter
-                if all([s.is_too_bright & s.min_exptime_reached for s in sequences]):
+                if all([s.is_too_bright and s.min_exptime_reached for s in sequences]):
                     self.logger.info("Terminating flat field sequence for the "
                                      f"{observation.filter_name} filter because all exposures are"
                                      " too bright at the minimum exposure time.")
                     return
             else:  # Sky getting fainter
-                if all([s.is_too_faint & s.max_exptime_reached for s in sequences]):
+                if all([s.is_too_faint and s.max_exptime_reached for s in sequences]):
                     self.logger.info("Terminating flat field sequence for the "
                                      f"{observation.filter_name} filter because all exposures are"
                                      " too faint at the maximum exposure time.")

--- a/src/huntsman/pocs/utils/flats.py
+++ b/src/huntsman/pocs/utils/flats.py
@@ -86,6 +86,50 @@ class FlatFieldSequence():
         """
         return self.status["is_finished"]
 
+    @property
+    def min_exptime_reached(self):
+        """ Check if the last exposure was at the minimum exposure time.
+        Returns:
+            bool: True if the min exposure time is reached, else False.
+        """
+        try:
+            return self._exptimes[-1] <= self._min_exptime
+        except KeyError:
+            return False
+
+    @property
+    def max_exptime_reached(self):
+        """ Check if the last exposure was at the maximum exposure time.
+        Returns:
+            bool: True if the max exposure time is reached, else False.
+        """
+        try:
+            return self._exptimes[-1] >= self._max_exptime
+        except KeyError:
+            return False
+
+    @property
+    def is_too_faint(self):
+        """ Check if the last exposure was too faint.
+        Returns:
+            bool: True if the last exposure was too faint, else False.
+        """
+        try:
+            return self._average_counts[-1] + self._counts_tolerance < self._target_counts
+        except KeyError:
+            return False
+
+    @property
+    def is_too_bright(self):
+        """ Check if the last exposure was too bright.
+        Returns:
+            bool: True if the last exposure was too bright, else False.
+        """
+        try:
+            return self._average_counts[-1] - self._counts_tolerance > self._target_counts
+        except KeyError:
+            return False
+
     def update(self, filename, exptime, time_start):
         """ Update the sequence data with the previous iteration.
         Args:

--- a/src/huntsman/pocs/utils/flats.py
+++ b/src/huntsman/pocs/utils/flats.py
@@ -94,7 +94,7 @@ class FlatFieldSequence():
         """
         try:
             return self._exptimes[-1] <= self._min_exptime
-        except KeyError:
+        except IndexError:
             return False
 
     @property
@@ -105,7 +105,7 @@ class FlatFieldSequence():
         """
         try:
             return self._exptimes[-1] >= self._max_exptime
-        except KeyError:
+        except IndexError:
             return False
 
     @property
@@ -116,7 +116,7 @@ class FlatFieldSequence():
         """
         try:
             return self._average_counts[-1] + self._counts_tolerance < self._target_counts
-        except KeyError:
+        except IndexError:
             return False
 
     @property
@@ -127,7 +127,7 @@ class FlatFieldSequence():
         """
         try:
             return self._average_counts[-1] - self._counts_tolerance > self._target_counts
-        except KeyError:
+        except IndexError:
             return False
 
     def update(self, filename, exptime, time_start):


### PR DESCRIPTION
Adds functionality to skip the current filter during flat fielding if:
- It is past midnight and all exposures are too bright at the minimum exposure time
OR
- It is not past midnight and all exposures are too faint at the maximum exposure time

This should save us a lot of time on the narrow band filters!

Closes #367.