### PR TITLE
read in a min_moon_sep value from scheduler config

### DIFF
--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -411,12 +411,13 @@ class HuntsmanObservatory(Observatory):
 
                 # Simple constraint for now
                 constraints = [
-                    constraint.MoonAvoidance(min_moon_sep=min_moon_sep),
+                    constraint.MoonAvoidance(),
                     constraint.Duration(30 * u.deg)]
 
                 # Create the Scheduler instance
                 self.scheduler = module.Scheduler(
                     self.observer, fields_file=fields_path, constraints=constraints)
+                self.scheduler.common_properties['min_moon_sep'] = min_moon_sep
                 self.logger.debug("Scheduler created")
             except ImportError as e:
                 raise error.NotFound(msg=e)


### PR DESCRIPTION
add the min_moon_sep value from config to the schedulers `common_properties` attribute so that it is used when `get_score()` is called on the MoonAvoidance constraint as part of `Scheduler.get_observation()`