### PR TITLE
Optionally skip coarse focus

### DIFF
--- a/src/huntsman/pocs/core.py
+++ b/src/huntsman/pocs/core.py
@@ -9,7 +9,7 @@ class HuntsmanPOCS(POCS):
         self._dome_open_states = []
         super().__init__(*args, **kwargs)
 
-    def run(self, initial_next_state='starting', skip_coarse_focus=False, *args, **kwargs):
+    def run(self, initial_next_state='starting', initial_focus=True, *args, **kwargs):
         """ Override the default initial_next_state parameter from "ready" to "starting".
         This allows us to call pocs.run() as normal, without needing to specify the initial next
         state explicitly.

--- a/src/huntsman/pocs/core.py
+++ b/src/huntsman/pocs/core.py
@@ -20,7 +20,8 @@ class HuntsmanPOCS(POCS):
                 Default False.
             *args, **kwargs: Parsed to POCS.run.
         """
-        if skip_coarse_focus:
+        # Override last coarse focus time if not doing initial coarse focus.
+        if initial_focus is False:
             self.observatory.last_coarse_focus_time = current_time()
         return super().run(initial_next_state=initial_next_state, *args, **kwargs)
 

--- a/src/huntsman/pocs/core.py
+++ b/src/huntsman/pocs/core.py
@@ -1,3 +1,4 @@
+from panoptes.utils.time import current_time
 from panoptes.pocs.core import POCS
 
 
@@ -8,15 +9,19 @@ class HuntsmanPOCS(POCS):
         self._dome_open_states = []
         super().__init__(*args, **kwargs)
 
-    def run(self, initial_next_state='starting', *args, **kwargs):
+    def run(self, initial_next_state='starting', skip_coarse_focus=False, *args, **kwargs):
         """ Override the default initial_next_state parameter from "ready" to "starting".
         This allows us to call pocs.run() as normal, without needing to specify the initial next
         state explicitly.
         Args:
             initial_next_state (str, optional): The first state the machine should move to from
                 the `sleeping` state, default `starting`.
+            skip_coarse_focus (bool, optional): If True, will skip the initial coarse focus.
+                Default False.
             *args, **kwargs: Parsed to POCS.run.
         """
+        if skip_coarse_focus:
+            self.observatory.last_coarse_focus_time = current_time()
         return super().run(initial_next_state=initial_next_state, *args, **kwargs)
 
     def _load_state(self, state, state_info=None):

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -53,7 +53,7 @@ class HuntsmanObservatory(Observatory):
         # Attributes for focusing
         self.last_coarse_focus_time = None
         self.coarse_focus_config = self.get_config('focusing.coarse')
-        self._focus_frequency = self.coarse_focus_config['frequency'] \
+        self._coarse_focus_frequency = self.coarse_focus_config['frequency'] \
                                 * u.Unit(self.coarse_focus_config['frequency_unit'])
         self._coarse_focus_filter = self.coarse_focus_config['filter_name']
 
@@ -92,7 +92,7 @@ class HuntsmanObservatory(Observatory):
         """
         if self.last_coarse_focus_time is None:
             return True
-        if current_time() - self.last_coarse_focus_time > self._focus_frequency:
+        if current_time() - self.last_coarse_focus_time > self._coarse_focus_frequency:
             return True
         return False
 

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -6,12 +6,9 @@ from astropy import units as u
 
 from panoptes.utils import error
 from panoptes.utils.utils import altaz_to_radec, get_quantity_value
-from panoptes.utils.library import load_module
 from panoptes.utils.time import current_time, wait_for_events, CountdownTimer
 
 from panoptes.pocs.observatory import Observatory
-from panoptes.pocs.scheduler import constraint
-from huntsman.pocs.scheduler.constraint import MoonAvoidance
 
 from huntsman.pocs.guide.bisque import Guide
 from panoptes.pocs.scheduler.observation.bias import BiasObservation
@@ -54,7 +51,7 @@ class HuntsmanObservatory(Observatory):
         self.flat_fields_required = take_flats
 
         # Attributes for focusing
-        self.last_focus_time = None
+        self.last_coarse_focus_time = None
         self.coarse_focus_config = self.get_config('focusing.coarse')
         self._focus_frequency = self.coarse_focus_config['frequency'] \
                                 * u.Unit(self.coarse_focus_config['frequency_unit'])
@@ -93,9 +90,9 @@ class HuntsmanObservatory(Observatory):
         using the amount of time specified by `focusing.coarse.frequency` in the config,
         else False.
         """
-        if self.last_focus_time is None:
+        if self.last_coarse_focus_time is None:
             return True
-        if current_time() - self.last_focus_time > self._focus_frequency:
+        if current_time() - self.last_coarse_focus_time > self._focus_frequency:
             return True
         return False
 
@@ -167,7 +164,7 @@ class HuntsmanObservatory(Observatory):
         result = super().autofocus_cameras(coarse=coarse, *args, **kwargs)
 
         # Update last focus time
-        self.last_focus_time = current_time()
+        self.last_coarse_focus_time = current_time()
 
         return result
 

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -97,7 +97,7 @@ def test_take_flat_fields(pocs):
 def test_autofocus_cameras(observatory):
     """
     """
-    observatory.last_focus_time = None
+    observatory.last_coarse_focus_time = None
     assert observatory.coarse_focus_required
     events = observatory.autofocus_cameras()
     wait_for_events(list(events.values()), timeout=60)

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -164,7 +164,7 @@ def test_ready_scheduling_1(pocs, pocstime_observe):
 
     pocs.initialize()
     pocs.startup()
-    pocs.observatory.last_focus_time = current_time()
+    pocs.observatory.last_coarse_focus_time = current_time()
     assert not pocs.observatory.coarse_focus_required
     pocs.get_ready()
     assert pocs.state == 'ready'
@@ -180,7 +180,7 @@ def test_ready_scheduling_2(pocs):
     pocs.set_config('simulator', ['camera', 'mount', 'power', 'weather'])
     os.environ['POCSTIME'] = '2020-04-29 08:40:00'
     pocs.initialize()
-    pocs.observatory.last_focus_time = current_time()
+    pocs.observatory.last_coarse_focus_time = current_time()
     assert not pocs.observatory.past_midnight
     assert not pocs.observatory.coarse_focus_required
     assert not pocs.is_dark(horizon='observe')
@@ -249,7 +249,7 @@ def test_morning_parking(pocs):
     os.environ['POCSTIME'] = '2020-04-29 19:30:00'
     pocs.set_config('simulator', ['camera', 'mount', 'weather', 'power'])
     pocs.initialize()
-    pocs.observatory.last_focus_time = current_time()
+    pocs.observatory.last_coarse_focus_time = current_time()
     pocs.startup()
     pocs.get_ready()
     assert pocs.state == 'ready'


### PR DESCRIPTION
Adds ability to call `pocs.run` and skip initial coarse focus.

Closes #400 