### PR TITLE
Fix nested-field observation

### DIFF
--- a/scripts/vignetting_sequence.py
+++ b/scripts/vignetting_sequence.py
@@ -26,7 +26,7 @@ from astroplan.plots import plot_sky
 from matplotlib import pylab as plt
 
 from panoptes.utils import utils
-from panoptes.pocs.scheduler.field import Field
+from huntsman.pocs.scheduler.field import Field
 from huntsman.pocs.scheduler.observation.base import Observation
 from huntsman.pocs.utils.huntsman import create_huntsman_observatory
 

--- a/src/huntsman/pocs/scheduler/observation/base.py
+++ b/src/huntsman/pocs/scheduler/observation/base.py
@@ -285,15 +285,22 @@ class CompoundObservation(AbstractObservation):
         # Check if the field is nested (i.e. another Compound Field)
         if isinstance(field, CompoundField):
 
+            exposure_list = list(self.exposure_list.keys())
+            exposure_step = self.batch_size * len(self._field)
+
             # Count the number of exposures for this subfield
-            exposure_cadence = self.batch_size * len(self.field)
-            exposures_this_field = len(self.exposure_list[field_idx:][::exposure_cadence])
+            # This is a bit tricky and could be improved by having an "update" method
+            exposures_this_field = 0
+            for i in range(self.batch_size):
+                exposure_offset = field_idx * self.batch_size + i
+                exposures_this_field += len(exposure_list[exposure_offset::exposure_step])
 
             # Get the corresponding nested field index
-            nested_field_idx = (exposures_this_field / field.batch_size) % len(self._field._field)
+            nested_field_idx = int(exposures_this_field / self.batch_size) % len(field)
 
             # Returned the nested field
             nested_field = field[nested_field_idx]
+
             return nested_field
 
         return field

--- a/src/huntsman/pocs/scheduler/observation/base.py
+++ b/src/huntsman/pocs/scheduler/observation/base.py
@@ -270,7 +270,6 @@ class CompoundObservation(AbstractObservation):
         super().__init__(field, min_nexp=min_nexp, exp_set_size=exp_set_size, *args, **kwargs)
 
     # Properties
-    # exposures_per_field = current_exp_num / (len(self._field) * batch_size)
 
     @property
     def field(self):


### PR DESCRIPTION
The `POCS` scheduler requires all field objects to be astropy `FixedTarget` instances. This means `observation.field` should always return a `huntsman.pocs.scheduler.field.Field` object, rather than e.g. a `huntsman.pocs.scheduler.field.CompoundField`. This was problematic when creating nested `CompoundField` objects, as `observation.field` currently would return an instance of `huntsman.pocs.scheduler.field.CompoundField`. 

Logic and docstrings updated accordingly. Do not merge until tested on Huntsman and new unit tests are added.