### PR TITLE
Fix pyro FW dark position bug

### DIFF
--- a/src/huntsman/pocs/filterwheel/pyro.py
+++ b/src/huntsman/pocs/filterwheel/pyro.py
@@ -69,6 +69,7 @@ class FilterWheel(AbstractFilterWheel):
         self._name = self._proxy.get("name", "filterwheel")
         self._model = self._proxy.get("model", "filterwheel")
         self._serial_number = self._proxy.get("uid", "filterwheel")
+        self._dark_position = self._proxy.get("_dark_position", "filterwheel")
 
         self.logger.debug(f"{self} connected.")
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -147,11 +147,11 @@ def test_fw_move_to_dark_position(camera):
 
     assert camera.filterwheel._dark_position is not None
 
-    camera.filterwheel.move_to(0, blocking=True)
+    camera.filterwheel.move_to(1, blocking=True)
     if camera.filterwheel.filter_name == camera.filterwheel._dark_position:
-        camera.filterwheel.move_to(1, blocking=True)
+        camera.filterwheel.move_to(2, blocking=True)
 
-    camera.filterwheel.move_to_dark_position()
+    camera.filterwheel.move_to_dark_position(blocking=True)
     assert camera.filterwheel.filter_name == camera.filterwheel._dark_position
 
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -148,11 +148,11 @@ def test_fw_move_to_dark_position(camera):
     assert camera.filterwheel._dark_position is not None
 
     camera.filterwheel.move_to(1, blocking=True)
-    if camera.filterwheel.filter_name == camera.filterwheel._dark_position:
+    if camera.filterwheel.position == camera.filterwheel._dark_position:
         camera.filterwheel.move_to(2, blocking=True)
 
     camera.filterwheel.move_to_dark_position(blocking=True)
-    assert camera.filterwheel.filter_name == camera.filterwheel._dark_position
+    assert camera.filterwheel.position == camera.filterwheel._dark_position
 
 
 def test_exposure(camera, tmpdir):

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -141,6 +141,20 @@ def test_move_filterwheel(camera):
     assert camera.filterwheel.position == 2
 
 
+def test_fw_move_to_dark_position(camera):
+    if not camera.filterwheel:
+        pytest.skip("Camera does not have a filterwheel.")
+
+    assert camera.filterwheel._dark_position is not None
+
+    camera.filterwheel.move_to(0, blocking=True)
+    if camera.filterwheel.filter_name == camera.filterwheel._dark_position:
+        camera.filterwheel.move_to(1, blocking=True)
+
+    camera.filterwheel.move_to_dark_position()
+    assert camera.filterwheel.filter_name == camera.filterwheel._dark_position
+
+
 def test_exposure(camera, tmpdir):
     """ Tests basic take_exposure functionality """
     fits_path = str(tmpdir.join('test_exposure.fits'))


### PR DESCRIPTION
Sets the `_dark_position` attribute when creating pyro filterwheel objects.