### PR TITLE
fix zwo defocus bug

### DIFF
--- a/src/huntsman/pocs/camera/zwo.py
+++ b/src/huntsman/pocs/camera/zwo.py
@@ -181,11 +181,19 @@ class Camera(AbstractSDKCamera):
         """ Reconnect to the camera. """
         Camera._driver.close_camera(self._handle)
         self._reset_usb()
-        return self.connect()
+        self.connect()
+        self.cooling_enabled = True
 
-    def take_exposure(self, defocused=False, *args, **kwargs):
-        """ Overrride class method to add defocusing offset. """
-        if defocused:
+    def take_exposure(self, *args, **kwargs):
+        """ Overrride class method to add defocusing offset.
+        Args:
+            defocused (bool, optional): If True, apply the defocusing offset before the exposure.
+                Default: False.
+            *args, **kwargs: Parsed to super().take_exposure.
+        Returns:
+            threading.Thread: The readout thread, which joins when readout has finished.
+        """
+        if kwargs.pop("defocused", False):
             required_focus_offset = self._defocus_offset - self._current_defocus_offset
             self.logger.debug(f"Applying focus offset of {self._defocus_offset} for defocused "
                               "exposure.")


### PR DESCRIPTION
Fixes a bug where the exposure time doesn't get properly set if `seconds` is provided as a positional parameter.

Closes #439 