### PR TITLE
Fix focus offset in camera class

### DIFF
--- a/src/huntsman/pocs/camera/pyro/client.py
+++ b/src/huntsman/pocs/camera/pyro/client.py
@@ -230,6 +230,13 @@ class Camera(AbstractCamera):
 
         return self._exposure_future
 
+    def take_observation(self, observation, *args, **kwargs):
+        """ Overrride class method to add defocusing offset.
+        TODO: Move to AbstractCamera.
+        """
+        return super().take_observation(observation, focus_offset=observation.focus_offset,
+                                        *args, **kwargs)
+
     def autofocus(self, blocking=False, timeout=None, coarse=False, *args, **kwargs):
         """
         Focuses the camera using the specified merit function. Optionally performs

--- a/src/huntsman/pocs/camera/zwo.py
+++ b/src/huntsman/pocs/camera/zwo.py
@@ -184,6 +184,7 @@ class Camera(AbstractSDKCamera):
         """ Overrride class method to add defocusing offset.
         Note that the focus offset is checked at the exposure level so that we don't end up
         moving the focuser back and forth unnecessarily.
+        TODO: Move to AbstractCamera.
         Args:
             defocused (bool, optional): If True, apply the defocusing offset before the exposure.
                 Default: False.
@@ -210,7 +211,9 @@ class Camera(AbstractSDKCamera):
         return super().take_exposure(*args, **kwargs)
 
     def take_observation(self, observation, *args, **kwargs):
-        """ Overrride class method to add defocusing offset. """
+        """ Overrride class method to add defocusing offset.
+        TODO: Move to AbstractCamera.
+        """
         return super().take_observation(observation, focus_offset=observation.focus_offset,
                                         *args, **kwargs)
 


### PR DESCRIPTION
Override needs to be in pyro client (really it should be in abstract camera)