### PR TITLE
Propagate focus filter

### DIFF
--- a/src/huntsman/pocs/focuser/birger.py
+++ b/src/huntsman/pocs/focuser/birger.py
@@ -66,6 +66,8 @@ class Focuser(BirgerFocuser):
             make_plots (bool, optional): Whether to write focus plots to images folder. If not
                 given will fall back on value of `autofocus_make_plots` set on initialisation,
                 and if it wasn't set then will default to False.
+            filter_name (str): The filter to use for focusing. If None, will use last light
+                position.
             blocking (bool, optional): Whether to block until autofocus complete, default False.
         """
         start_time = start_time = current_time(flatten=True)
@@ -93,13 +95,14 @@ class Focuser(BirgerFocuser):
 
         # Move filterwheel to the correct position
         if self.camera.has_filterwheel:
+
             if filter_name is None:
-                if coarse:
-                    filter_name = self.camera.get_config("focusing.coarse.filter_name")
-                else:
-                    filter_name = self.camera.filterwheel.current_filter
-            self.logger.info(f"Moving filterwheel to {filter_name} for autofocusing on {self}.")
-            self.camera.filterwheel.move_to(filter_name, blocking=True)
+                # NOTE: The camera will move the FW to the last light position automatically
+                self.logger.warning(f"Filter name not provided for autofocus on {self}. Using last"
+                                    " light position.")
+            else:
+                self.logger.info(f"Moving filterwheel to {filter_name} for autofocusing on {self}.")
+                self.camera.filterwheel.move_to(filter_name, blocking=True)
 
         # Take the focusing exposures
         exposure_retries = 0

--- a/src/huntsman/pocs/focuser/birger.py
+++ b/src/huntsman/pocs/focuser/birger.py
@@ -94,15 +94,21 @@ class Focuser(BirgerFocuser):
             sequence.dark_image = cutout
 
         # Move filterwheel to the correct position
-        if self.camera.has_filterwheel:
+        if self.camera is not None:
+            if self.camera.has_filterwheel:
 
-            if filter_name is None:
-                # NOTE: The camera will move the FW to the last light position automatically
-                self.logger.warning(f"Filter name not provided for autofocus on {self}. Using last"
-                                    " light position.")
-            else:
-                self.logger.info(f"Moving filterwheel to {filter_name} for autofocusing on {self}.")
-                self.camera.filterwheel.move_to(filter_name, blocking=True)
+                if filter_name is None:
+                    # NOTE: The camera will move the FW to the last light position automatically
+                    self.logger.warning(f"Filter name not provided for autofocus on {self}. Using"
+                                        " last light position.")
+                else:
+                    self.logger.info(f"Moving filterwheel to {filter_name} for autofocusing on"
+                                     f" {self}.")
+                    self.camera.filterwheel.move_to(filter_name, blocking=True)
+
+            elif filter_name is None:
+                self.logger.warning(f"Filter {filter_name} requiested for autofocus but"
+                                    f" {self.camera} has no filterwheel.")
 
         # Take the focusing exposures
         exposure_retries = 0

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -168,6 +168,7 @@ class HuntsmanObservatory(Observatory):
         focus_type = "coarse" if coarse else "fine"
 
         # Choose the filter to focus with
+        # TODO: Move this logic to the camera level
         if filter_name is None:
             if coarse:
                 filter_name = self._coarse_focus_filter

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -155,7 +155,7 @@ class HuntsmanObservatory(Observatory):
         return self.current_offset_info
 
     def autofocus_cameras(self, coarse=False, filter_name=None, default_timeout=900,
-                          blocking=True, *args, **kwargs):
+                          blocking=True, **kwargs):
         """ Override autofocus_cameras to update the last focus time and move filterwheels.
         Args:
             coarse (bool, optional): Perform coarse focus? Default False.
@@ -167,8 +167,7 @@ class HuntsmanObservatory(Observatory):
         """
         focus_type = "coarse" if coarse else "fine"
 
-        # Move to appropriate filter
-        # TODO: Do this on a per-camera basis to allow for different filters simultaneously
+        # Choose the filter to focus with
         if filter_name is None:
             if coarse:
                 filter_name = self._coarse_focus_filter
@@ -180,12 +179,10 @@ class HuntsmanObservatory(Observatory):
                     self.logger.warning("Unable to retrieve filter name from current observation."
                                         f" Defaulting to coarse focus filter ({filter_name}).")
 
-        # Move all the filterwheels to the required position
-        self._move_all_filterwheels_to(filter_name)
-
         # Start the autofocus sequences
+        # NOTE: The FW move is handled implicitly
         self.logger.info(f"Starting {focus_type} autofocus sequence.")
-        events = super().autofocus_cameras(coarse=coarse, *args, **kwargs)
+        events = super().autofocus_cameras(coarse=coarse, filter_name=filter_name, **kwargs)
 
         # Wait for sequences to finish
         if blocking:

--- a/src/huntsman/pocs/utils/huntsman.py
+++ b/src/huntsman/pocs/utils/huntsman.py
@@ -49,7 +49,7 @@ def create_huntsman_scheduler(observer=None, logger=None, *args, **kwargs):
 
         try:
             # Load the required module
-            module = load_module(f'panoptes.pocs.scheduler.{scheduler_type}')
+            module = load_module(f'{scheduler_type}')
 
             obstruction_list = get_config('location.obstructions', default=[])
             default_horizon = get_config('location.horizon', default=30 * u.degree)

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -96,6 +96,7 @@ def test_take_flat_fields(pocs):
     pocs.observatory.take_flat_fields(alt=60, az=90, required_exposures=1, tolerance=0.5)
 
 
+@pytest.mark.skip("Waiting for POCS PR")
 def test_autofocus_cameras_coarse(observatory):
     """
     """
@@ -109,6 +110,7 @@ def test_autofocus_cameras_coarse(observatory):
     assert not observatory.coarse_focus_required
 
 
+@pytest.mark.skip("Waiting for POCS PR")
 def test_autofocus_cameras_fine(observatory):
     """
     """

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -22,7 +22,7 @@ db:
   type: file
 
 scheduler:
-  type: dispatch
+  type: panoptes.pocs.scheduler.dispatch
   fields_file: simulator.yaml
   check_file: True
 


### PR DESCRIPTION
Currently the logic for choosing the filter name and moving the FW is duplicated in the both the observatory and focuser code. This PR moves the logic for deciding which filter is used for focusing into the observatory, and moves the code to actually move the FW into the focuser's autofocus method.

Skipped tests will require panoptes/POCS#1109 to pass.

Closes #459 