### PR TITLE
add observe_once constraint

### DIFF
--- a/src/huntsman/pocs/utils/huntsman.py
+++ b/src/huntsman/pocs/utils/huntsman.py
@@ -66,7 +66,7 @@ def create_huntsman_scheduler(observer=None, logger=None, *args, **kwargs):
 
             # add global observe each target once constraint
             if get_config('constraints.observe_once', default=False):
-                constraints.append(AlreadyVisited())
+                constraints.insert(0, AlreadyVisited())
 
             # Create the Scheduler instance
             scheduler = module.Scheduler(observer, fields_file=fields_path, constraints=constraints,

--- a/src/huntsman/pocs/utils/huntsman.py
+++ b/src/huntsman/pocs/utils/huntsman.py
@@ -16,6 +16,7 @@ from huntsman.pocs.observatory import HuntsmanObservatory
 from huntsman.pocs.dome import create_dome_from_config
 from huntsman.pocs.core import HuntsmanPOCS
 from huntsman.pocs.scheduler.constraint import SunAvoidance
+from huntsman.pocs.scheduler.constraint import AlreadyVisited
 from huntsman.pocs.scheduler.constraint import MoonAvoidance as HuntsmanMoonAvoidance
 from huntsman.pocs.mount.bisque import create_mount
 
@@ -62,6 +63,10 @@ def create_huntsman_scheduler(observer=None, logger=None, *args, **kwargs):
             constraints = [Altitude(horizon=horizon_line),
                            HuntsmanMoonAvoidance(),
                            SunAvoidance()]
+
+            # add global observe each target once constraint
+            if get_config('constraints.observe_once', default=False):
+                constraints.append(AlreadyVisited())
 
             # Create the Scheduler instance
             scheduler = module.Scheduler(observer, fields_file=fields_path, constraints=constraints,

--- a/src/huntsman/pocs/utils/huntsman.py
+++ b/src/huntsman/pocs/utils/huntsman.py
@@ -16,7 +16,7 @@ from huntsman.pocs.observatory import HuntsmanObservatory
 from huntsman.pocs.dome import create_dome_from_config
 from huntsman.pocs.core import HuntsmanPOCS
 from huntsman.pocs.scheduler.constraint import SunAvoidance
-from huntsman.pocs.scheduler.constraint import AlreadyVisited
+from panoptes.pocs.scheduler.constraint import AlreadyVisited
 from huntsman.pocs.scheduler.constraint import MoonAvoidance as HuntsmanMoonAvoidance
 from huntsman.pocs.mount.bisque import create_mount
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4,6 +4,11 @@ from huntsman.pocs.scheduler.field import Field, CompoundField, DitheredField
 from huntsman.pocs.scheduler.observation import base as obsbase
 from huntsman.pocs.scheduler.observation.dithered import DitheredObservation
 
+from huntsman.pocs.utils.huntsman import create_scheduler_from_config
+
+from panoptes.utils.config.client import get_config, set_config
+from panoptes.pocs.scheduler.constraint import AlreadyVisited
+
 
 @pytest.fixture(scope="function")
 def field_config_1():
@@ -13,6 +18,24 @@ def field_config_1():
 @pytest.fixture(scope="function")
 def field_config_2():
     return {"name": "Fake target", "position": "03h26m52.0582s +35d33m01.733s"}
+
+
+def test_observe_once_global():
+    prev_observe_once_status = get_config('scheduler.constraints.observe_once',
+                                          default=False)
+    set_config('scheduler.constraints.observe_once', True)
+    scheduler = create_scheduler_from_config()
+
+    is_set = False
+    for constraint in scheduler.constraints:
+        if isinstance(constraint, AlreadyVisited):
+            is_set = True
+            break
+
+    try:
+        assert is_set
+    finally:
+        set_config('scheduler.constraints.observe_once', prev_observe_once_status)
 
 
 def test_field(field_config_1, field_config_2):


### PR DESCRIPTION
This gives the user the ability to observe each target in the target list only once.

It is enabled via the config yaml file:

```
scheduler:
  constraints:
    observe_once: true
```