### PR TITLE
Limit number of times we enter the darks state

### DIFF
--- a/src/huntsman/pocs/core.py
+++ b/src/huntsman/pocs/core.py
@@ -21,7 +21,7 @@ class HuntsmanPOCS(POCS):
         max_dark_per_interval = self.get_config("calibs.dark.max_blocks_per_interval", 3)
         self._dark_state_times = deque(maxlen=max_dark_per_interval)
 
-        dark_interval = self.get_config("calibs.dark_interval_hours", 6)
+        dark_interval = self.get_config("calibs.dark.dark_interval_hours", 6)
         self._dark_interval = get_quantity_value(dark_interval, u.hour) * u.hour
 
         # Hack solution to provide POCS.is_safe functionality to observatory

--- a/src/huntsman/pocs/states/huntsman/starting.py
+++ b/src/huntsman/pocs/states/huntsman/starting.py
@@ -12,7 +12,7 @@ def on_enter(event_data):
     pocs.observatory.prepare_cameras()
     pocs.observatory.mount.unpark()
 
-    if not pocs.is_weather_safe() or not pocs.is_dark(horizon="flat"):  # TODO: Use scheduler?
+    if pocs.should_take_darks:
         pocs.next_state = "taking_darks"
     else:
         pocs.next_state = "ready"  # If not safe, the state machine goes to park automatically

--- a/src/huntsman/pocs/states/huntsman/taking_darks.py
+++ b/src/huntsman/pocs/states/huntsman/taking_darks.py
@@ -10,3 +10,6 @@ def on_enter(event_data):
     # Take dark frames
     pocs.say("Taking dark frames.")
     pocs.observatory.take_dark_observation()
+
+    # Register the completion of the dark state
+    pocs.register_dark_state_completion()


### PR DESCRIPTION
Adds new `should_take_darks` property to the `HuntsmanPOCS` class. 

New config items:
`calibs.dark.max_blocks_per_interval`: The maximum number of times to enter the state.
`calibs.dark.dark_interval_hours`: The time interval in which the maximum number pertains.

Each time the dark state is completed, the time is registered inside the `HuntsmanPOCS` instance. If there have been too many darks collected recently (defined by the new config items) then the dark state will be vetoed.

Closes #527