### PR TITLE
testing config should be set to not use alternate weather data

### DIFF
--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -134,9 +134,9 @@ archiver:
 
 alt_weather_sources:
   aat_weather:
-    use: True
+    use: false
   skymapper_weather:
-    use: True
+    use: false
 
 AutofocusSequence:
   merit_function_name: "huntsman.pocs.utils.focus.fourier_focus_metric"


### PR DESCRIPTION
Forgot to change this, don't want tests to try and use alt weather data.