### PR TITLE
retrieve `.timeout` camera attribute instead of `._timeout` in pyro camera client connect()

### DIFF
--- a/src/huntsman/pocs/camera/pyro/client.py
+++ b/src/huntsman/pocs/camera/pyro/client.py
@@ -171,7 +171,7 @@ class Camera(AbstractHuntsmanCamera):
         self._file_extension = self._proxy.get("file_extension")
         self._is_cooled_camera = self._proxy.get("is_cooled_camera")
         self._filter_type = self._proxy.get("filter_type")
-        self._timeout = self._proxy.get("_timeout")
+        self._timeout = self._proxy.get("timeout")
 
         # Set up proxies for remote camera's events required by base class
         self._exposure_event = RemoteEvent(self._uri, event_type="camera")

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -28,9 +28,11 @@ scheduler:
   fields_file: simulator.yaml
   check_file: True
   constraints:
+    - name: panoptes.pocs.scheduler.constraint.Altitude
     - name: panoptes.pocs.scheduler.constraint.MoonAvoidance
       options:
         separation: 15
+    - name: panoptes.pocs.scheduler.constraint.Duration
 
 directories:
   base: /huntsman

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -27,6 +27,10 @@ scheduler:
   type: panoptes.pocs.scheduler.dispatch
   fields_file: simulator.yaml
   check_file: True
+  constraints:
+    - name: panoptes.pocs.scheduler.constraint.MoonAvoidance
+      options:
+        separation: 15
 
 directories:
   base: /huntsman


### PR DESCRIPTION
The `connect()` method of the pyro camera client class tries to fetch the value of a `_timeout` attribute from the the proxy camera object. This is not defined for the `Camera` class but seems to exists as `timeout` attribute instead.