### PR TITLE
Changes to bring HPOCS in line with how POCS handles `observing_event`

### DIFF
--- a/src/huntsman/pocs/camera/group.py
+++ b/src/huntsman/pocs/camera/group.py
@@ -122,12 +122,12 @@ class CameraGroup(PanBase):
 
             # Take the exposure and catch errors
             try:
-                event = camera.take_observation(observation, **obs_kwargs)
+                camera.take_observation(observation, **obs_kwargs)
             except error.PanError as err:
                 self.logger.error(f"{err!r}")
                 return None
 
-            return event
+            return camera.is_observing
 
         # Start the exposures and return events
         return dispatch_parallel(func, self.camera_names)

--- a/src/huntsman/pocs/camera/pyro/client.py
+++ b/src/huntsman/pocs/camera/pyro/client.py
@@ -140,6 +140,18 @@ class Camera(AbstractHuntsmanCamera):
             self._exposure_event.clear()
 
     @property
+    def is_observing(self):
+        return self._proxy.get("is_observing")
+
+    @is_observing.setter
+    def is_observing(self, is_observing):
+        """Set or clear the remote exposure event."""
+        if is_observing:
+            self._is_observing_event.set()
+        else:
+            self._is_observing_event.clear()
+
+    @property
     def is_temperature_stable(self):
         return self._proxy.get("is_temperature_stable")
 
@@ -176,6 +188,7 @@ class Camera(AbstractHuntsmanCamera):
         # Set up proxies for remote camera's events required by base class
         self._exposure_event = RemoteEvent(self._uri, event_type="camera")
         self._focus_event = RemoteEvent(self._uri, event_type="focuser")
+        self._is_observing_event = RemoteEvent(self._uri, event_type="observation")
 
         self._connected = True
         self.logger.debug(f"{self} connected.")

--- a/src/huntsman/pocs/camera/pyro/service.py
+++ b/src/huntsman/pocs/camera/pyro/service.py
@@ -95,6 +95,15 @@ class CameraService(object):
             kwargs.pop("blocking")
         self._readout_thread = self._camera.take_exposure(*args, **kwargs)
 
+    def take_observation(self, *args, **kwargs):
+        """Proxy call to the camera client.
+
+        This method will strip any `blocking` parameter that is passed so Pyro can handle the blocking appropriately.
+        """
+        with suppress(KeyError):
+            kwargs.pop("blocking")
+        self._camera.take_observation(*args, **kwargs)
+
     def autofocus(self, *args, **kwargs):
         """ Start the autofocus non-blocking so that camera server can still respond to
         status requests.

--- a/src/huntsman/pocs/camera/pyro/service.py
+++ b/src/huntsman/pocs/camera/pyro/service.py
@@ -20,7 +20,8 @@ class CameraService(object):
     """
     _event_locations = {"camera": ("_camera", "_is_exposing_event"),
                         "focuser": ("_focus_event",),
-                        "filterwheel": ("_camera", "filterwheel", "_move_event")}
+                        "filterwheel": ("_camera", "filterwheel", "_move_event"),
+                        "observation": ("_camera", "_is_observing_event")}
 
     def __init__(self, device_name=None, logger=None):
         """

--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -508,9 +508,10 @@ class HuntsmanObservatory(Observatory):
                 start_times[cam_name] = current_time()
 
                 try:
-                    events[cam_name] = camera.take_observation(
+                    camera.take_observation(
                         observation, headers=headers, filename=filenames[cam_name],
                         exptime=exptimes[cam_name])
+                    events[cam_name] = camera.is_observing
                 except error.PanError as err:
                     self.logger.error(f"{err!r}")
                     self.logger.warning("Continuing with flat observation after error.")
@@ -603,7 +604,7 @@ class HuntsmanObservatory(Observatory):
             self._assert_safe(**kwargs)
 
             # Check if all cameras have finished
-            if all([e.is_set() for e in events.values()]):
+            if all([e() for e in events.values()]):
                 break
             time.sleep(sleep)
 

--- a/src/huntsman/pocs/utils/pyro/event.py
+++ b/src/huntsman/pocs/utils/pyro/event.py
@@ -3,13 +3,14 @@ from Pyro5.api import Proxy
 
 event_types = {"camera",
                "focuser",
-               "filterwheel"}
+               "filterwheel",
+               "observation"}
 
 
 class RemoteEvent(Event):
     """Interface for threading.Events of a remote camera or its subcomponents.
 
-    Current supported types are: `camera`, `focuser`, `filterwheel`.
+    Current supported types are: `camera`, `focuser`, `filterwheel`, `observation`.
     """
 
     def __init__(self, uri, event_type):


### PR DESCRIPTION
In POCS the `camera.take_observation()` method was changed to return  a `metadata` object instead of the `observation_event` it was before.

https://github.com/panoptes/POCS/blob/83ced36d0d6bd85af31a728246b47da470584d7d/src/panoptes/pocs/camera/camera.py#L460

Now `observation_event` has been made into a class attribute called `camera._is_observing_event` which can be interacted with via @property attribute `camera.is_observing`.

Changes in this PR are to bring HPOCS in line with the above chagnes to pocs but also required making some changes to the pyro camera client class and some of the code related to handling remote events through pyro.