### PR TITLE
Allow config set mount home & park timeouts

### DIFF
--- a/src/huntsman/pocs/mount/__init__.py
+++ b/src/huntsman/pocs/mount/__init__.py
@@ -30,7 +30,7 @@ def create_mount_simulator(mount_info=None,
     # Set mount device info to simulator
     set_config('mount', mount_config)
 
-    earth_location = earth_location or create_location_from_config().earth_location
+    earth_location = earth_location or create_location_from_config()['earth_location']
 
     logger.debug(f"Loading mount driver: {mount_config['driver']}")
     try:

--- a/src/huntsman/pocs/mount/__init__.py
+++ b/src/huntsman/pocs/mount/__init__.py
@@ -1,0 +1,45 @@
+from contextlib import suppress
+
+from panoptes.pocs.utils.location import create_location_from_config
+from panoptes.pocs.utils.logger import get_logger
+from panoptes.utils import error
+from panoptes.utils.library import load_module
+from panoptes.utils.config.client import get_config, set_config
+
+logger = get_logger()
+
+
+def create_mount_simulator(mount_info=None,
+                           earth_location=None,
+                           db_type='memory',
+                           *args, **kwargs):
+    # Remove mount simulator
+    current_simulators = get_config('simulator', default=[])
+    logger.warning(f'Current simulators: {current_simulators}')
+    with suppress(ValueError):
+        current_simulators.remove('mount')
+
+    mount_config = mount_info or {
+        'model': 'Mount Simulator',
+        'driver': 'huntsman.pocs.mount.simulator',
+        'serial': {
+            'port': '/dev/FAKE'
+        }
+    }
+
+    # Set mount device info to simulator
+    set_config('mount', mount_config)
+
+    earth_location = earth_location or create_location_from_config().earth_location
+
+    logger.debug(f"Loading mount driver: {mount_config['driver']}")
+    try:
+        module = load_module(f"{mount_config['driver']}")
+    except error.NotFound as e:
+        raise error.MountNotFound(f'Error loading mount module: {e!r}')
+
+    mount_obj = module.Mount(earth_location, db_type=db_type, *args, **kwargs)
+
+    logger.success(f"{mount_config['driver'].title()} mount created")
+
+    return mount_obj

--- a/src/huntsman/pocs/mount/bisque.py
+++ b/src/huntsman/pocs/mount/bisque.py
@@ -37,3 +37,23 @@ class Mount(BisqueMount):
         time.sleep(10)
 
         return super().slew_to_target(*args, **kwargs)
+
+    def home_and_park(self, *args, home_timeout=None, park_timeout=None, ** kwargs):
+        """ Convenience method to first slew to the home position and then park.
+        """
+        if not self.is_parked:
+            # default timeout is 120 seconds but sometimes this isnt enough
+            self.slew_to_home(blocking=True, timeout=home_timeout, **kwargs)
+
+            # Reinitialize from home seems to always do the trick of getting us to
+            # correct side of pier for parking
+            self._is_initialized = False
+            self.initialize()
+            # default timeout is 120 seconds but sometimes this isnt enough
+            self.park(*args, timeout=park_timeout, **kwargs)
+
+            while self.is_slewing and not self.is_parked:
+                time.sleep(5)
+                self.logger.debug("Slewing to park, sleeping for 5 seconds")
+
+        self.logger.debug("Mount parked")

--- a/src/huntsman/pocs/mount/simulator.py
+++ b/src/huntsman/pocs/mount/simulator.py
@@ -5,10 +5,10 @@ import time
 class Mount(SimulatorMount):
     """ Override class to use Huntsman mount functionality for tests. """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    # def __init__(self, *args, **kwargs):
+    #     super().__init__(*args, **kwargs)
 
-    def home_and_park(self, *args, home_timeout=None, park_timeout=None, ** kwargs):
+    def home_and_park(self, *args, home_timeout=None, park_timeout=None, **kwargs):
         """ Convenience method to first slew to the home position and then park.
         """
         if not self.is_parked:
@@ -20,10 +20,16 @@ class Mount(SimulatorMount):
             self._is_initialized = False
             self.initialize()
             # default timeout is 120 seconds but sometimes this isnt enough
-            self.park(*args, timeout=park_timeout, **kwargs)
+            self.park(*args, timeout=park_timeout, ** kwargs)
 
             while self.is_slewing and not self.is_parked:
                 time.sleep(5)
                 self.logger.debug("Slewing to park, sleeping for 5 seconds")
 
         self.logger.debug("Mount parked")
+
+    def park(self, *args, **kwargs):
+        # panoptes mount simulator version of `park()` doesn't accept kwargs
+        # but HuntsmanMount.park() and huntsman states do, so need to catch the kwargs
+        # here and not pass them on to the simulator `park()`
+        super().park()

--- a/src/huntsman/pocs/mount/simulator.py
+++ b/src/huntsman/pocs/mount/simulator.py
@@ -1,9 +1,28 @@
 from panoptes.pocs.mount.simulator import Mount as SimulatorMount
-from huntsman.pocs.mount.bisque import HuntsmanMount
 
 
-class Mount(SimulatorMount, HuntsmanMount):
+class Mount(SimulatorMount):
     """ Override class to use Huntsman mount functionality for tests. """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    def home_and_park(self, *args, home_timeout=None, park_timeout=None, ** kwargs):
+        """ Convenience method to first slew to the home position and then park.
+        """
+        if not self.is_parked:
+            # default timeout is 120 seconds but sometimes this isnt enough
+            self.slew_to_home(blocking=True, timeout=home_timeout, **kwargs)
+
+            # Reinitialize from home seems to always do the trick of getting us to
+            # correct side of pier for parking
+            self._is_initialized = False
+            self.initialize()
+            # default timeout is 120 seconds but sometimes this isnt enough
+            self.park(*args, timeout=park_timeout, **kwargs)
+
+            while self.is_slewing and not self.is_parked:
+                time.sleep(5)
+                self.logger.debug("Slewing to park, sleeping for 5 seconds")
+
+        self.logger.debug("Mount parked")

--- a/src/huntsman/pocs/mount/simulator.py
+++ b/src/huntsman/pocs/mount/simulator.py
@@ -1,4 +1,5 @@
 from panoptes.pocs.mount.simulator import Mount as SimulatorMount
+import time
 
 
 class Mount(SimulatorMount):

--- a/src/huntsman/pocs/mount/simulator.py
+++ b/src/huntsman/pocs/mount/simulator.py
@@ -1,0 +1,9 @@
+from panoptes.pocs.mount.simulator import Mount as SimulatorMount
+from huntsman.pocs.mount.bisque import HuntsmanMount
+
+
+class Mount(SimulatorMount, HuntsmanMount):
+    """ Override class to use Huntsman mount functionality for tests. """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)

--- a/src/huntsman/pocs/states/huntsman/parking.py
+++ b/src/huntsman/pocs/states/huntsman/parking.py
@@ -1,3 +1,4 @@
+from turtle import home
 from panoptes.utils.error import TheSkyXTimeout
 
 
@@ -15,9 +16,12 @@ def on_enter(event_data):
 
     # sometimes parking seems to arbitrarily time out, allow for n retries before raising error
     n = pocs.get_config('mount.num_park_attempts', default=3)
+    home_timeout = pocs.get_config('mount.home_timeout', default=3)
+    park_timeout = pocs.get_config('mount.park_timeout', default=3)
     for i in range(n):
         try:
-            pocs.observatory.mount.home_and_park()
+            pocs.observatory.mount.home_and_park(
+                home_timeout=home_timeout, park_timeout=park_timeout)
         except TheSkyXTimeout:
             if i + 1 < n:
                 pocs.say(f"Attempt {i+1}/{n} at parking timed out, trying again.")

--- a/src/huntsman/pocs/states/huntsman/parking.py
+++ b/src/huntsman/pocs/states/huntsman/parking.py
@@ -16,8 +16,8 @@ def on_enter(event_data):
 
     # sometimes parking seems to arbitrarily time out, allow for n retries before raising error
     n = pocs.get_config('mount.num_park_attempts', default=3)
-    home_timeout = pocs.get_config('mount.home_timeout', default=3)
-    park_timeout = pocs.get_config('mount.park_timeout', default=3)
+    home_timeout = pocs.get_config('mount.home_timeout', default=180)
+    park_timeout = pocs.get_config('mount.park_timeout', default=180)
     for i in range(n):
         try:
             pocs.observatory.mount.home_and_park(

--- a/tests/test_huntsman.py
+++ b/tests/test_huntsman.py
@@ -7,7 +7,7 @@ from panoptes.pocs.core import POCS
 from panoptes.pocs.dome import create_dome_from_config
 from panoptes.pocs.mount import create_mount_from_config
 from panoptes.pocs.scheduler import create_scheduler_from_config
-from panoptes.pocs.mount import create_mount_simulator
+from huntsman.pocs.mount import create_mount_simulator
 from huntsman.pocs.camera.utils import create_cameras_from_config
 from huntsman.pocs.observatory import HuntsmanObservatory as Observatory
 from huntsman.pocs.utils.huntsman import create_huntsman_pocs

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -7,7 +7,7 @@ from panoptes.utils.time import current_time
 
 from panoptes.pocs.utils.location import create_location_from_config
 from panoptes.pocs.scheduler import create_scheduler_from_config
-from panoptes.pocs.mount import create_mount_simulator
+from huntsman.pocs.mount import create_mount_simulator
 
 from huntsman.pocs.core import HuntsmanPOCS
 from huntsman.pocs.camera.utils import create_cameras_from_config

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -5,7 +5,7 @@ from panoptes.utils.time import current_time
 
 from panoptes.pocs.utils.location import create_location_from_config
 from panoptes.pocs.scheduler import create_scheduler_from_config
-from panoptes.pocs.mount import create_mount_simulator
+from huntsman.pocs.mount import create_mount_simulator
 from panoptes.utils.config.client import set_config
 from panoptes.pocs.dome import create_dome_simulator
 

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -89,9 +89,9 @@ cameras:
         dark_position: blank
 
 mount:
-  brand: bisque
+  brand: ioptron
   model: 30
-  driver: huntsman.pocs.mount.simulator
+  driver: ioptron
   serial:
     port: /dev/ttyUSB0
     timeout: 0.

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -89,15 +89,17 @@ cameras:
         dark_position: blank
 
 mount:
-  brand: ioptron
+  brand: bisque
   model: 30
-  driver: ioptron
+  driver: huntsman.pocs.mount.simulator
   serial:
     port: /dev/ttyUSB0
     timeout: 0.
     baudrate: 9600
   non_sidereal_available: True
   num_park_attempts: 3
+  home_timeout: 180
+  park_timeout: 180
 
 pointing:
   exptime: 30


### PR DESCRIPTION
default timeouts appear to be too short (120s) which leads to a timeout exception that kills pocs states... often early in the morning which results in a lot of missed morning flats.

closes #575 