### PR TITLE
Fix openshutdome loops #556 #486

### DIFF
--- a/src/huntsman/pocs/states/huntsman/parking.py
+++ b/src/huntsman/pocs/states/huntsman/parking.py
@@ -6,7 +6,12 @@ def on_enter(event_data):
 
     # Clear any current observation
     pocs.observatory.current_observation = None
-    pocs.observatory.close_dome()
+    # if sun is below startup horizon and weather is safe dont close the dome
+    # this is prevent the observatory open and closing if there are no targets
+    # to schedule or if its waiting for focus horizon
+    # this also helps keep inside dome temp equal to outside
+    if not pocs.observatory.is_safe(horizon='startup'):
+        pocs.observatory.close_dome()
 
     pocs.say("I'm takin' it on home and then parking.")
     pocs.observatory.mount.home_and_park()

--- a/src/huntsman/pocs/states/huntsman/sleeping.py
+++ b/src/huntsman/pocs/states/huntsman/sleeping.py
@@ -18,6 +18,9 @@ def on_enter(event_data):
         pocs.say("Waiting for startup horizon from sleeping state.")
 
         while not pocs.is_dark(horizon="startup"):
+            if not pocs.observatory.is_safe(horizon='startup'):
+                pocs.say("Weather has become unsafe while sleeping, closing dome.")
+                pocs.observatory.close_dome()
             time.sleep(check_delay)
 
         pocs.say("Finished waiting for startup horizon.")


### PR DESCRIPTION
Simplest way to resolve the open/shut dome loops is to only close the dome in the parking state if the weather is bad or we are above the startup horizon. This saves the shutter battery and also keeps the internal dome temps equalised through out the night. The sleeping state will also now check to see if it is still ok to keep the dome open (again based on weather and the startup horizon)

closes #556 and #486